### PR TITLE
v2 → main: AgentConsole (context-runtime model plane) + MCP adapter & web_search server

### DIFF
--- a/context_runtime/adapters/model_openai.py
+++ b/context_runtime/adapters/model_openai.py
@@ -38,14 +38,24 @@ class OpenAICompatibleModel:
         base_envs: tuple[str, ...] = ("AGENT_LLM_BASE_URL", "OPENAI_BASE_URL"),
         cost_per_1k: float = 0.0,
     ) -> "OpenAICompatibleModel | None":
-        """Build from environment, or ``None`` when no API key is present (offline)."""
+        """Build from environment, or ``None`` when nothing is configured (offline → StubModel).
+
+        Priority: an explicit OpenAI/agent key, else the self-hosted OpenAI-compatible endpoint
+        the agentic-os apps already point at (``REDEVOPS_LLM_BASE_URL`` / ``REDEVOPS_LLM_MODEL`` —
+        typically a keyless on-prem DeepSeek). That keeps the agent on our own model plane without
+        spreading a provider key across every container.
+        """
         key = next((os.environ[k] for k in key_envs if os.environ.get(k)), None)
-        if not key:
-            return None
-        base = next((os.environ[b] for b in base_envs if os.environ.get(b)), "https://api.openai.com/v1")
-        model = os.environ.get(model_env, default_model)
-        tier = Tier(name="chat", model=model, base_url=base.rstrip("/"), api_key=key, cost_per_1k=cost_per_1k)
-        return cls([tier])
+        if key:
+            base = next((os.environ[b] for b in base_envs if os.environ.get(b)), "https://api.openai.com/v1")
+            model = os.environ.get(model_env, default_model)
+            return cls([Tier(name="chat", model=model, base_url=base.rstrip("/"), api_key=key, cost_per_1k=cost_per_1k)])
+        rbase = os.environ.get("REDEVOPS_LLM_BASE_URL")
+        if rbase:
+            rmodel = os.environ.get("REDEVOPS_LLM_MODEL", "DeepSeek-V4-Flash")
+            rkey = os.environ.get("REDEVOPS_LLM_KEY") or "sk-noauth"  # vLLM ignores it; header must exist
+            return cls([Tier(name="chat", model=rmodel, base_url=rbase.rstrip("/"), api_key=rkey, cost_per_1k=cost_per_1k)])
+        return None
 
     def _tier_for(self, capability: str) -> Tier:
         return self.tiers.get(self.default_tier) or next(iter(self.tiers.values()))
@@ -56,8 +66,9 @@ class OpenAICompatibleModel:
         if req.system:
             messages.append({"role": "system", "content": req.system})
         messages.extend(dict(m) for m in req.messages)
-        # gpt-5.x uses max_completion_tokens and rejects a non-default temperature; keep it minimal.
-        payload: dict = {"model": tier.model, "messages": messages, "max_completion_tokens": req.max_tokens}
+        # gpt-5.x wants max_completion_tokens; self-hosted vLLM/DeepSeek want max_tokens. Branch on host.
+        tok_key = "max_completion_tokens" if "openai.com" in (tier.base_url or "") else "max_tokens"
+        payload: dict = {"model": tier.model, "messages": messages, tok_key: req.max_tokens}
         if req.tools:
             payload["tools"] = list(req.tools)
         request = urllib.request.Request(

--- a/context_runtime/adapters/model_openai.py
+++ b/context_runtime/adapters/model_openai.py
@@ -1,0 +1,98 @@
+"""OpenAICompatibleModel — a dependency-light ``ModelPlugin`` (SPEC §4.3).
+
+Speaks the OpenAI ``/chat/completions`` wire format over the *stdlib* (urllib), so it
+drives OpenAI gpt-5.x, DeepSeek, vLLM, Ollama — any compatible endpoint — with the same
+``ModelRequest → ModelResult`` contract and cost-tiered ``Tier`` routing as
+``LiteLLMModel``, but **without the litellm dependency**. That matters because the slim
+agent containers install only the base ``context-runtime`` (no ``[litellm]`` extra): this
+adapter lets those apps run their conversational agent *on the Context Runtime model
+plane* rather than reaching around it to a raw provider SDK. Degrade to ``StubModel``
+when no key is configured (``from_env`` returns ``None``).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+from ..types import ModelCapabilities, ModelRequest, ModelResult, PluginInfo
+from .model_litellm import Tier  # dataclass only; importing it does not pull in litellm
+
+
+class OpenAICompatibleModel:
+    """ModelPlugin over an OpenAI-compatible endpoint using only the stdlib."""
+
+    def __init__(self, tiers: list[Tier], default_tier: str = "chat", timeout: float = 40.0):
+        self.tiers = {t.name: t for t in tiers}
+        self.default_tier = default_tier
+        self.timeout = timeout
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        model_env: str = "AGENT_LLM_MODEL",
+        default_model: str = "gpt-5.5",
+        key_envs: tuple[str, ...] = ("AGENT_LLM_KEY", "OPENAI_API_KEY"),
+        base_envs: tuple[str, ...] = ("AGENT_LLM_BASE_URL", "OPENAI_BASE_URL"),
+        cost_per_1k: float = 0.0,
+    ) -> "OpenAICompatibleModel | None":
+        """Build from environment, or ``None`` when no API key is present (offline)."""
+        key = next((os.environ[k] for k in key_envs if os.environ.get(k)), None)
+        if not key:
+            return None
+        base = next((os.environ[b] for b in base_envs if os.environ.get(b)), "https://api.openai.com/v1")
+        model = os.environ.get(model_env, default_model)
+        tier = Tier(name="chat", model=model, base_url=base.rstrip("/"), api_key=key, cost_per_1k=cost_per_1k)
+        return cls([tier])
+
+    def _tier_for(self, capability: str) -> Tier:
+        return self.tiers.get(self.default_tier) or next(iter(self.tiers.values()))
+
+    def complete(self, req: ModelRequest) -> ModelResult:
+        tier = self._tier_for(req.capability)
+        messages: list[dict] = []
+        if req.system:
+            messages.append({"role": "system", "content": req.system})
+        messages.extend(dict(m) for m in req.messages)
+        # gpt-5.x uses max_completion_tokens and rejects a non-default temperature; keep it minimal.
+        payload: dict = {"model": tier.model, "messages": messages, "max_completion_tokens": req.max_tokens}
+        if req.tools:
+            payload["tools"] = list(req.tools)
+        request = urllib.request.Request(
+            tier.base_url + "/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={"Authorization": "Bearer " + (tier.api_key or ""), "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as resp:
+                d = json.load(resp)
+        except urllib.error.HTTPError as e:  # surface provider errors so the caller can fall back
+            detail = e.read()[:300].decode("utf-8", "ignore")
+            raise RuntimeError(f"model http {e.code}: {detail}") from e
+        choice = (d.get("choices") or [{}])[0]
+        text = (choice.get("message") or {}).get("content") or ""
+        usage = d.get("usage") or {}
+        ptoks = int(usage.get("prompt_tokens") or self.count_tokens(json.dumps(messages), tier.model))
+        ctoks = int(usage.get("completion_tokens") or self.count_tokens(text, tier.model))
+        cost = (ptoks + ctoks) / 1000.0 * tier.cost_per_1k
+        return ModelResult(
+            text=text.strip(),
+            model=tier.model,
+            tier=tier.name,
+            prompt_tokens=ptoks,
+            completion_tokens=ctoks,
+            est_cost_usd=round(cost, 6),
+            models_used=(tier.model,),
+        )
+
+    def capabilities(self, model: str) -> ModelCapabilities:
+        return ModelCapabilities(max_context_tokens=128000, tool_calling=True, structured_outputs=True)
+
+    def count_tokens(self, text: str, model: str) -> int:
+        return max(1, len(text) // 4)  # ~4 chars/token, matches StubModel's estimate
+
+    def info(self) -> PluginInfo:
+        return PluginInfo(name="openai_compatible", kind="model", capabilities=frozenset(self.tiers))

--- a/context_runtime/integrations/agent_console.py
+++ b/context_runtime/integrations/agent_console.py
@@ -229,16 +229,15 @@ class AgentConsole:
             "concrete steps. If the passages don't cover it, say so plainly."
         )
         prompt = f"Guide:\n{context}\n\nQuestion: {message}"
-        res = self.model.complete(
-            ModelRequest(messages=({"role": "user", "content": prompt},), system=system, max_tokens=600)
-        )
-        return {
-            "intent": "help",
-            "text": res.text or hits[0].text,
-            "evidence": evidence,
-            "model": res.model,
-            "cost_usd": res.est_cost_usd,
-        }
+        try:
+            res = self.model.complete(
+                ModelRequest(messages=({"role": "user", "content": prompt},), system=system, max_tokens=600)
+            )
+            return {"intent": "help", "text": res.text or hits[0].text, "evidence": evidence,
+                    "model": res.model, "cost_usd": res.est_cost_usd}
+        except Exception:  # noqa: BLE001 — model outage → fall back to the top grounded passage
+            return {"intent": "help", "text": f"{hits[0].text}\n\n(Grounded in the {self.tenant} guide [1].)",
+                    "evidence": evidence, "model": self.model.info().name}
 
     def _answer_tool(self, name: str, args: dict) -> dict:
         result = self.registry.run(name, args)
@@ -254,11 +253,15 @@ class AgentConsole:
                 "below. Answer them directly and concisely from that data. Do not invent numbers."
             )
             prompt = f"Tool `{name}` returned:\n{summary}\n\nAnswer the user."
-            res = self.model.complete(
-                ModelRequest(messages=({"role": "user", "content": prompt},), system=system, max_tokens=500)
-            )
-            body = res.text or summary
-            model_name = res.model
+            try:
+                res = self.model.complete(
+                    ModelRequest(messages=({"role": "user", "content": prompt},), system=system, max_tokens=500)
+                )
+                body = res.text or summary
+                model_name = res.model
+            except Exception:  # noqa: BLE001 — model outage → return the raw tool summary
+                body = summary
+                model_name = self.model.info().name
         else:
             body = summary or "Done."
             model_name = self.model.info().name

--- a/context_runtime/integrations/agent_console.py
+++ b/context_runtime/integrations/agent_console.py
@@ -1,0 +1,358 @@
+"""AgentConsole — a reusable conversational agent that runs entirely on the Context
+Runtime stack.
+
+Every agentic-os app wraps a complex OSS core (ERPNext, Lago, OpenSCAP, CrowdSec, …); the
+dashboards show state but leave users to learn the tool and hunt for the right action.
+``AgentConsole`` is the one chat surface that fixes both: ask *"how do I…?"* or *"explain
+this"* and it answers grounded in the app's guide; ask it to *do* something and it runs a
+tool — always showing its work.
+
+It is deliberately built on our own three planes, not a raw provider SDK:
+
+* **context-runtime** — generation goes through a Context Runtime ``ModelPlugin``
+  (``OpenAICompatibleModel`` when a key is present, else the offline ``StubModel``), so the
+  same cost-tiered ``ModelRequest → ModelResult`` contract and accounting apply.
+* **redevops-rag** — the *"how do I / explain"* path is grounded by retrieval over the app's
+  primer, honouring redevops-rag's ``hybrid_search`` contract. The dependency-free
+  ``PrimerIndex`` here is the offline path; the ``[rag]`` extra swaps in the real reranked
+  index without changing callers.
+* **agent-harness** — actions are dispatched through the harness ``ToolRegistry`` +
+  ``ApprovalPolicy``, so a side-effecting tool is gated and every decision is audited.
+
+One console per app: give it a ``tenant`` name, a ``primer`` (the product knowledge), and a
+list of ``tools`` (each bound to that app's core API). ``respond()`` returns a transparent
+payload the chat panel renders; ``panel_html()`` returns the panel itself.
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from ..adapters.model_openai import OpenAICompatibleModel
+from ..adapters.model_stub import StubModel
+from ..tools.base import ApprovalPolicy, ToolRegistry, ToolResult, ToolSpec
+from ..types import ModelRequest
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(text: str) -> list[str]:
+    return _WORD.findall(text.lower())
+
+
+# ──────────────────────────── grounding (redevops-rag contract) ────────────────────────────
+
+
+@dataclass
+class Chunk:
+    idx: int
+    text: str
+    score: float = 0.0
+
+
+class PrimerIndex:
+    """Dependency-free ranked retrieval over the app primer — the offline redevops-rag path.
+
+    Splits the primer into blank-line-separated passages and ranks them by TF·IDF overlap
+    with the query. Same ``search(query, k) -> ranked passages`` shape as redevops-rag's
+    ``hybrid_search``; the ``[rag]`` extra replaces this with the reranked vector path.
+    """
+
+    def __init__(self, primer: str):
+        passages = [p.strip() for p in re.split(r"\n\s*\n", primer.strip()) if p.strip()]
+        self.passages = passages
+        self._toks = [_tokens(p) for p in passages]
+        df: Counter = Counter()
+        for toks in self._toks:
+            for t in set(toks):
+                df[t] += 1
+        n = max(1, len(passages))
+        self._idf = {t: math.log(1 + n / c) for t, c in df.items()}
+
+    def search(self, query: str, k: int = 4) -> list[Chunk]:
+        q = set(_tokens(query))
+        if not q or not self.passages:
+            return []
+        scored: list[Chunk] = []
+        for i, toks in enumerate(self._toks):
+            tf = Counter(toks)
+            score = sum(tf[t] * self._idf.get(t, 0.0) for t in q)
+            if score > 0:
+                scored.append(Chunk(idx=i, text=self.passages[i], score=round(score, 3)))
+        scored.sort(key=lambda c: c.score, reverse=True)
+        return scored[:k]
+
+
+# ──────────────────────────── tools (agent-harness) ────────────────────────────
+
+
+ToolFn = Callable[[dict], Any]
+
+
+class _Tool:
+    """Adapt a plain callable into an agent-harness ``ToolPlugin``."""
+
+    def __init__(self, spec: ToolSpec, fn: ToolFn):
+        self._spec = spec
+        self._fn = fn
+
+    def spec(self) -> ToolSpec:
+        return self._spec
+
+    def run(self, args: dict) -> ToolResult:
+        try:
+            out = self._fn(args or {})
+        except Exception as e:  # noqa: BLE001 — never let a tool crash the console
+            return ToolResult(ok=False, error=str(e), text=f"[tool error] {e}")
+        if isinstance(out, ToolResult):
+            return out
+        if isinstance(out, dict) and ("text" in out or "data" in out):
+            return ToolResult(ok=True, data=out.get("data"), text=str(out.get("text", "")))
+        return ToolResult(ok=True, data=out, text="" if out is None else str(out))
+
+
+def tool(
+    name: str,
+    description: str,
+    fn: ToolFn,
+    *,
+    parameters: dict | None = None,
+    side_effecting: bool = False,
+) -> _Tool:
+    """Declare an app capability. ``fn`` takes an args dict and returns a dict/str/ToolResult."""
+    return _Tool(
+        ToolSpec(
+            name=name,
+            description=description,
+            parameters=parameters or {"type": "object", "properties": {}},
+            side_effecting=side_effecting,
+        ),
+        fn,
+    )
+
+
+# ──────────────────────────── the console ────────────────────────────
+
+
+_CLASSIFY_SYS = (
+    "You route a user's message for the assistant of a business app. Reply with ONLY a JSON "
+    'object: {"mode":"tool"|"help","tool":<tool name or null>,"args":{...},"reason":<short>}. '
+    'Use "tool" when the message asks to DO or SHOW something a listed tool covers; use "help" '
+    "for how-to / explain / what-is questions. Never invent a tool name."
+)
+
+
+class AgentConsole:
+    def __init__(
+        self,
+        tenant: str,
+        primer: str,
+        tools: list[_Tool] | tuple[_Tool, ...] = (),
+        *,
+        suggestions: list[str] | tuple[str, ...] = (),
+        subtitle: str = "",
+        model: Any = None,
+        allow_side_effects: list[str] | None = None,
+    ):
+        self.tenant = tenant
+        self.subtitle = subtitle or f"Ask about {tenant} — how things work, or get something done."
+        self.primer = primer.strip()
+        self.index = PrimerIndex(self.primer)
+        self.suggestions = list(suggestions)
+        self.model = model if model is not None else (OpenAICompatibleModel.from_env() or StubModel())
+        self.registry = ToolRegistry(ApprovalPolicy(mode="allowlist", allow=list(allow_side_effects or [])))
+        self._tools: dict[str, _Tool] = {}
+        for t in tools:
+            self.registry.register(t)
+            self._tools[t.spec().name] = t
+
+    # ---- helpers -------------------------------------------------------------
+
+    @property
+    def _live(self) -> bool:
+        return not isinstance(self.model, StubModel)
+
+    def _tool_catalog(self) -> str:
+        return "\n".join(f"- {n}: {t.spec().description}" for n, t in self._tools.items()) or "(no tools)"
+
+    def _keyword_route(self, message: str) -> dict:
+        """Deterministic fallback when the model can't return JSON (offline / parse fail)."""
+        toks = set(_tokens(message))
+        best, best_score = None, 0
+        for name, t in self._tools.items():
+            vocab = set(_tokens(name.replace("_", " ") + " " + t.spec().description))
+            score = len(toks & vocab)
+            if score > best_score:
+                best, best_score = name, score
+        if best and best_score >= 1:
+            return {"mode": "tool", "tool": best, "args": {}, "reason": "keyword match"}
+        return {"mode": "help", "tool": None, "args": {}, "reason": "default to help"}
+
+    def classify(self, message: str) -> dict:
+        if not self._tools or not self._live:
+            return self._keyword_route(message)
+        prompt = f"Tools:\n{self._tool_catalog()}\n\nMessage: {message}\n\nJSON:"
+        try:
+            res = self.model.complete(
+                ModelRequest(messages=({"role": "user", "content": prompt},), system=_CLASSIFY_SYS, max_tokens=200)
+            )
+            m = re.search(r"\{.*\}", res.text, re.S)
+            data = json.loads(m.group(0)) if m else {}
+            mode = data.get("mode")
+            tool_name = data.get("tool")
+            if mode == "tool" and tool_name in self._tools:
+                return {"mode": "tool", "tool": tool_name, "args": data.get("args") or {}, "reason": data.get("reason", "")}
+            if mode == "help":
+                return {"mode": "help", "tool": None, "args": {}, "reason": data.get("reason", "")}
+        except Exception:  # noqa: BLE001 — any failure drops to the deterministic router
+            pass
+        return self._keyword_route(message)
+
+    def _answer_help(self, message: str) -> dict:
+        hits = self.index.search(message, k=4)
+        evidence = [{"n": i + 1, "text": h.text, "score": h.score} for i, h in enumerate(hits)]
+        if not hits:
+            body = "I don't have that in the guide yet. Try the dashboard, or ask about a specific action."
+            return {"intent": "help", "text": body, "evidence": [], "model": self.model.info().name}
+        context = "\n\n".join(f"[{e['n']}] {e['text']}" for e in evidence)
+        if not self._live:
+            # extractive offline answer: lead with the top passage, cite it
+            body = f"{hits[0].text}\n\n(Grounded in the {self.tenant} guide [1].)"
+            return {"intent": "help", "text": body, "evidence": evidence, "model": self.model.info().name}
+        system = (
+            f"You are the assistant for {self.tenant}. Answer the user's how-to / explain question using "
+            "ONLY the numbered guide passages. Cite them inline like [1]. Be concise and practical — give the "
+            "concrete steps. If the passages don't cover it, say so plainly."
+        )
+        prompt = f"Guide:\n{context}\n\nQuestion: {message}"
+        res = self.model.complete(
+            ModelRequest(messages=({"role": "user", "content": prompt},), system=system, max_tokens=600)
+        )
+        return {
+            "intent": "help",
+            "text": res.text or hits[0].text,
+            "evidence": evidence,
+            "model": res.model,
+            "cost_usd": res.est_cost_usd,
+        }
+
+    def _answer_tool(self, name: str, args: dict) -> dict:
+        result = self.registry.run(name, args)
+        gate = self.registry.audit[-1] if self.registry.audit else {"decision": "read-only"}
+        evidence = [{"tool": name, "args": args, "gate": gate.get("reason") or gate.get("decision", ""), "ok": result.ok}]
+        summary = result.text or (json.dumps(result.data)[:800] if result.data is not None else "")
+        if not result.ok:
+            body = summary or "That action needs confirmation before it can run."
+            return {"intent": "action", "tool": name, "text": body, "evidence": evidence, "data": result.data, "approved": False}
+        if self._live and summary:
+            system = (
+                f"You are the assistant for {self.tenant}. The user asked something and a tool returned the data "
+                "below. Answer them directly and concisely from that data. Do not invent numbers."
+            )
+            prompt = f"Tool `{name}` returned:\n{summary}\n\nAnswer the user."
+            res = self.model.complete(
+                ModelRequest(messages=({"role": "user", "content": prompt},), system=system, max_tokens=500)
+            )
+            body = res.text or summary
+            model_name = res.model
+        else:
+            body = summary or "Done."
+            model_name = self.model.info().name
+        return {"intent": "action", "tool": name, "text": body, "evidence": evidence, "data": result.data, "approved": True, "model": model_name}
+
+    def respond(self, message: str) -> dict:
+        message = (message or "").strip()
+        if not message:
+            return {"intent": "help", "text": "Ask me anything about " + self.tenant + ".", "evidence": []}
+        route = self.classify(message)
+        if route["mode"] == "tool" and route["tool"] in self._tools:
+            out = self._answer_tool(route["tool"], route.get("args") or {})
+        else:
+            out = self._answer_help(message)
+        out["route"] = route.get("reason", "")
+        return out
+
+    # ---- the panel -----------------------------------------------------------
+
+    def panel_html(self, mount: str = "agent", endpoint: str = "api/agent") -> str:
+        chips = "".join(
+            f'<button class="ac-chip" onclick="acAsk(this.textContent)">{_esc(s)}</button>' for s in self.suggestions
+        )
+        return _PANEL_TMPL.format(
+            mount=mount, endpoint=endpoint, tenant=_esc(self.tenant), subtitle=_esc(self.subtitle), chips=chips
+        )
+
+
+def _esc(s: str) -> str:
+    return (
+        str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+    )
+
+
+_PANEL_TMPL = """
+<div id="{mount}" class="ac-panel">
+  <div class="ac-head"><span class="ac-dot"></span><div><div class="ac-title">{tenant} · Assistant</div>
+    <div class="ac-sub">{subtitle}</div></div></div>
+  <div id="{mount}-log" class="ac-log"></div>
+  <div class="ac-chips">{chips}</div>
+  <form class="ac-form" onsubmit="acSend(event)">
+    <input id="{mount}-in" class="ac-in" autocomplete="off" placeholder="Ask, or tell me what to do…"/>
+    <button class="ac-send" type="submit">Send</button>
+  </form>
+</div>
+<style>
+  .ac-panel{{background:#141416;border:1px solid #2b2b30;border-radius:14px;padding:14px;color:#e7e5ea;
+    font:14px/1.5 Roboto,system-ui,sans-serif;display:flex;flex-direction:column;gap:10px;max-width:720px}}
+  .ac-head{{display:flex;gap:10px;align-items:center}}
+  .ac-dot{{width:9px;height:9px;border-radius:50%;background:#4fd1c5;box-shadow:0 0 10px #4fd1c5}}
+  .ac-title{{font-weight:600}} .ac-sub{{color:#9b99a1;font-size:12px}}
+  .ac-log{{display:flex;flex-direction:column;gap:10px;max-height:52vh;overflow:auto;padding:2px}}
+  .ac-msg{{padding:9px 12px;border-radius:12px;max-width:88%}}
+  .ac-you{{align-self:flex-end;background:#2b3a49}} .ac-bot{{align-self:flex-start;background:#1d1d21;border:1px solid #2b2b30}}
+  .ac-work{{margin-top:7px;font-size:12px;color:#8f8d95}}
+  .ac-work summary{{cursor:pointer;color:#4fd1c5}}
+  .ac-ev{{border-top:1px solid #2b2b30;padding:5px 0;white-space:pre-wrap}}
+  .ac-chips{{display:flex;flex-wrap:wrap;gap:6px}}
+  .ac-chip{{background:#1d1d21;border:1px solid #2b2b30;color:#c7c5ca;border-radius:20px;padding:5px 11px;
+    font-size:12px;cursor:pointer}} .ac-chip:hover{{border-color:#4fd1c5}}
+  .ac-form{{display:flex;gap:8px}}
+  .ac-in{{flex:1;background:#0e0e10;border:1px solid #2b2b30;border-radius:10px;padding:10px;color:#e7e5ea}}
+  .ac-send{{background:#4fd1c5;color:#08312d;border:0;border-radius:10px;padding:0 16px;font-weight:600;cursor:pointer}}
+  .ac-tag{{display:inline-block;font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:#08312d;
+    background:#4fd1c5;border-radius:4px;padding:1px 6px;margin-right:6px}}
+  .ac-tag.help{{background:#c7b3ff}} .ac-tag.deny{{background:#ff9b9b}}
+</style>
+<script>
+(function(){{
+  var M="{mount}",EP="{endpoint}";
+  window.acAsk=function(t){{document.getElementById(M+"-in").value=t;acSend();}};
+  window.acSend=function(e){{
+    if(e&&e.preventDefault)e.preventDefault();
+    var inp=document.getElementById(M+"-in"),q=(inp.value||"").trim();if(!q)return;inp.value="";
+    add("you",esc(q));var wait=add("bot","…");
+    fetch(EP,{{method:"POST",headers:{{"Content-Type":"application/json"}},body:JSON.stringify({{message:q}})}})
+      .then(function(r){{return r.json();}}).then(function(d){{wait.remove();render(d);}})
+      .catch(function(){{wait.remove();add("bot","(the assistant is offline right now)");}});
+  }};
+  function add(who,html){{var log=document.getElementById(M+"-log");var m=document.createElement("div");
+    m.className="ac-msg ac-"+(who==="you"?"you":"bot");m.innerHTML=html;log.appendChild(m);
+    log.scrollTop=log.scrollHeight;return m;}}
+  function render(d){{
+    var tag=d.intent==="action"?(d.approved===false?'<span class="ac-tag deny">needs ok</span>':'<span class="ac-tag">action'+(d.tool?" · "+esc(d.tool):"")+'</span>'):'<span class="ac-tag help">guide</span>';
+    var html=tag+"<div>"+esc(d.text||"").replace(/\\n/g,"<br>")+"</div>";
+    var ev=(d.evidence||[]);
+    if(ev.length){{var rows=ev.map(function(e){{
+      if(e.text!=null)return '<div class="ac-ev">['+e.n+'] '+esc(e.text)+'</div>';
+      return '<div class="ac-ev">tool <b>'+esc(e.tool||"")+'</b> · gate: '+esc(e.gate||"")+' · '+(e.ok?"ok":"blocked")+'</div>';
+    }}).join("");
+      html+='<details class="ac-work"><summary>show work'+(d.model?" · "+esc(d.model):"")+'</summary>'+rows+'</details>';}}
+    add("bot",html);
+  }}
+  function esc(s){{return String(s==null?"":s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");}}
+}})();
+</script>
+"""

--- a/context_runtime/integrations/agent_console.py
+++ b/context_runtime/integrations/agent_console.py
@@ -170,6 +170,23 @@ class AgentConsole:
             self.registry.register(t)
             self._tools[t.spec().name] = t
 
+    def mount_mcp(self, client, *, prefix: str | None = None, allow: list[str] | None = None) -> list[str]:
+        """Mount an external MCP tool server's tools into this console.
+
+        Registers each tool in the agent-harness registry AND the classify/dispatch catalog, so
+        the assistant can pick and run them like any native tool. Read-only MCP tools
+        (``readOnlyHint``) run ungated; side-effecting ones stay gated unless named in ``allow``.
+        Returns the mounted tool names.
+        """
+        from ..tools.mcp import mount_mcp as _mount_mcp
+
+        names = _mount_mcp(self.registry, client, prefix=prefix)
+        for n in names:
+            self._tools[n] = self.registry.get(n)  # classify() sees it, respond() dispatches it
+        if allow:
+            self.registry.policy.allow.update(allow)
+        return names
+
     # ---- helpers -------------------------------------------------------------
 
     @property

--- a/context_runtime/tools/mcp.py
+++ b/context_runtime/tools/mcp.py
@@ -1,0 +1,259 @@
+"""MCP adapter: mount external MCP tool servers into the agent-harness registry gated by ApprovalPolicy.
+
+Minimal JSON-RPC 2.0 client for the Model Context Protocol. Supports stdio (subprocess)
+and HTTP (httpx POST) transports. Tools are wrapped as ToolPlugins so side-effects are
+routed through the registry's ApprovalPolicy. Do not list tools at import time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .base import ToolPlugin, ToolRegistry, ToolResult, ToolSpec
+
+
+class MCPClient:
+    """Minimal JSON-RPC 2.0 MCP client.
+
+    Create via classmethods:
+        MCPClient.stdio(command, env=None)
+        MCPClient.http(base_url, headers=None)
+    """
+
+    def __init__(self) -> None:
+        self._req_id: int = 0
+        self._stdio_proc: subprocess.Popen[str] | None = None
+        self._http_base: str | None = None
+        self._http_headers: dict[str, str] = {}
+        self._initialized: bool = False
+        self._closed: bool = False
+
+    @classmethod
+    def stdio(cls, command: list[str], env: dict[str, str] | None = None) -> MCPClient:
+        self = cls()
+        env_dict = os.environ.copy()
+        if env:
+            env_dict.update({k: str(v) for k, v in env.items()})
+        self._stdio_proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=env_dict,
+        )
+        return self
+
+    @classmethod
+    def http(cls, base_url: str, headers: dict[str, str] | None = None) -> MCPClient:
+        self = cls()
+        self._http_base = base_url
+        self._http_headers = dict(headers or {})
+        return self
+
+    def _next_id(self) -> int:
+        self._req_id += 1
+        return self._req_id
+
+    def _exchange(self, req: dict[str, Any]) -> dict[str, Any]:
+        """Send req and return the JSON-RPC response dict (may contain 'error')."""
+        if self._closed:
+            return {"jsonrpc": "2.0", "id": req.get("id"), "error": {"code": -32000, "message": "client closed"}}
+        if self._stdio_proc is not None:
+            try:
+                line = json.dumps(req, separators=(",", ":")) + "\n"
+                assert self._stdio_proc.stdin is not None
+                self._stdio_proc.stdin.write(line)
+                self._stdio_proc.stdin.flush()
+                while True:
+                    outline = self._stdio_proc.stdout.readline()
+                    if not outline:
+                        try:
+                            err = self._stdio_proc.stderr.read(256) or ""
+                        except Exception:
+                            err = ""
+                        return {"jsonrpc": "2.0", "id": req.get("id"), "error": {"code": -32000, "message": f"stdio closed: {err}"}}
+                    try:
+                        resp = json.loads(outline.strip())
+                    except json.JSONDecodeError:
+                        continue
+                    rid = resp.get("id")
+                    if rid == req.get("id") or "id" not in resp:
+                        # accept matching or (rare) no-id but we treat as notif only on dedicated path
+                        if "id" in resp:
+                            return resp
+                        continue  # notification while waiting, keep reading for our id
+                    # other id? ignore
+            except Exception as e:
+                return {"jsonrpc": "2.0", "id": req.get("id"), "error": {"code": -32603, "message": f"stdio transport: {e}"}}
+        elif self._http_base is not None:
+            try:
+                headers = {"Content-Type": "application/json", **self._http_headers}
+                r = httpx.post(self._http_base, json=req, headers=headers, timeout=30.0)
+                r.raise_for_status()
+                return r.json()
+            except Exception as e:
+                return {"jsonrpc": "2.0", "id": req.get("id"), "error": {"code": -32603, "message": f"http transport: {e}"}}
+        return {"jsonrpc": "2.0", "id": req.get("id"), "error": {"code": -32603, "message": "no transport configured"}}
+
+    def _send_notif(self, notif: dict[str, Any]) -> None:
+        if self._closed:
+            return
+        if self._stdio_proc is not None:
+            try:
+                line = json.dumps(notif, separators=(",", ":")) + "\n"
+                assert self._stdio_proc.stdin is not None
+                self._stdio_proc.stdin.write(line)
+                self._stdio_proc.stdin.flush()
+            except Exception:
+                pass
+        elif self._http_base is not None:
+            try:
+                headers = {"Content-Type": "application/json", **self._http_headers}
+                httpx.post(self._http_base, json=notif, headers=headers, timeout=10.0)
+            except Exception:
+                pass
+
+    def _rpc(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        rid = self._next_id()
+        req = {"jsonrpc": "2.0", "id": rid, "method": method, "params": params or {}}
+        resp = self._exchange(req)
+        if "error" in resp and resp.get("error"):
+            err = resp["error"]
+            code = err.get("code", -1)
+            msg = err.get("message", str(err))
+            data = err.get("data")
+            raise RuntimeError(f"MCP {method} error {code}: {msg}{f' {data}' if data else ''}")
+        return resp.get("result") or {}
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        params: dict[str, Any] = {
+            "protocolVersion": "2024-11-05",
+            "clientInfo": {"name": "context-runtime", "version": "0.1"},
+        }
+        self._rpc("initialize", params)
+        notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        self._send_notif(notif)
+        self._initialized = True
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        if not self._initialized:
+            self.initialize()
+        result = self._rpc("tools/list")
+        if isinstance(result, dict):
+            return result.get("tools", [])
+        return result if isinstance(result, list) else []
+
+    def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self._rpc("tools/call", {"name": name, "arguments": arguments or {}})
+
+    def close(self) -> None:
+        self._closed = True
+        if self._stdio_proc is not None:
+            try:
+                assert self._stdio_proc.stdin is not None
+                self._stdio_proc.stdin.close()
+                self._stdio_proc.terminate()
+                self._stdio_proc.wait(timeout=0.5)
+            except Exception:
+                pass
+            self._stdio_proc = None
+        self._http_base = None
+
+
+@dataclass
+class MCPToolPlugin:
+    """ToolPlugin wrapper for a single MCP tool descriptor + shared live MCPClient."""
+
+    _desc: dict[str, Any]
+    _client: MCPClient
+    _name: str
+    _default_side: bool = True
+
+    def __init__(self, tool_desc: dict[str, Any], client: MCPClient, *, name: str | None = None, default_side_effecting: bool = True) -> None:
+        # support dataclass init + override for manual
+        object.__setattr__(self, "_desc", tool_desc)
+        object.__setattr__(self, "_client", client)
+        object.__setattr__(self, "_name", name or tool_desc.get("name", "unnamed"))
+        object.__setattr__(self, "_default_side", default_side_effecting)
+
+    def spec(self) -> ToolSpec:
+        mcp_name = self._desc.get("name") or self._name
+        desc = self._desc.get("description") or ""
+        schema = self._desc.get("inputSchema") or self._desc.get("input_schema") or {"type": "object", "properties": {}}
+        ann = self._desc.get("annotations") or {}
+        read_only = bool(ann.get("readOnlyHint")) if "readOnlyHint" in ann else False
+        side = (not read_only) if "readOnlyHint" in ann else bool(self._default_side)
+        return ToolSpec(
+            name=self._name,
+            description=desc,
+            parameters=schema,
+            side_effecting=side,
+        )
+
+    def run(self, args: dict) -> ToolResult:
+        try:
+            res = self._client.call_tool(self._desc.get("name") or self._name, args)
+        except Exception as e:
+            return ToolResult(ok=False, error=str(e), text=f"[error] {self._name}: {e}")
+        is_err = bool(res.get("isError", False))
+        content_list = res.get("content") or []
+        texts: list[str] = []
+        for block in content_list:
+            if isinstance(block, dict) and block.get("type") == "text":
+                t = block.get("text") or ""
+                if t:
+                    texts.append(t)
+            elif block:
+                texts.append(str(block))
+        text = "\n".join(texts)
+        if "structuredContent" in res and res.get("structuredContent") is not None:
+            data = res["structuredContent"]
+        else:
+            data = res.get("content", res)
+        err = None
+        if is_err:
+            err = res.get("error") or (text or "mcp tool returned isError")
+        return ToolResult(ok=not is_err, data=data, text=text, error=err)
+
+
+def mount_mcp(
+    registry: ToolRegistry,
+    client: MCPClient,
+    *,
+    prefix: str | None = None,
+    default_side_effecting: bool = True,
+) -> list[str]:
+    """Initialize client if needed, list tools, register each wrapped MCPToolPlugin.
+
+    Registered name = f'{prefix}.{name}' if prefix else name.
+    Returns the list of registered tool names.
+    """
+    try:
+        if not client._initialized:
+            client.initialize()
+    except Exception:
+        pass  # list_tools may still work or caller will see []
+    registered: list[str] = []
+    try:
+        tools = client.list_tools()
+    except Exception:
+        return registered
+    for tdesc in tools:
+        if not isinstance(tdesc, dict) or not tdesc.get("name"):
+            continue
+        raw = tdesc["name"]
+        reg_name = f"{prefix}.{raw}" if prefix else raw
+        plugin = MCPToolPlugin(tdesc, client, name=reg_name, default_side_effecting=default_side_effecting)
+        registry.register(plugin)
+        registered.append(reg_name)
+    return registered

--- a/context_runtime/tools/mcp_servers/__init__.py
+++ b/context_runtime/tools/mcp_servers/__init__.py
@@ -1,0 +1,6 @@
+"""Small, self-contained MCP tool servers shipped with Context Runtime.
+
+These are reference MCP servers (stdio transport) that any AgentConsole app can mount via
+``context_runtime.tools.mcp.MCPClient.stdio`` — proving the agent-harness ↔ MCP bridge with
+real, keyless tools.
+"""

--- a/context_runtime/tools/mcp_servers/web_search.py
+++ b/context_runtime/tools/mcp_servers/web_search.py
@@ -1,0 +1,135 @@
+"""web_search — a keyless, dependency-free MCP web-search server (stdio transport).
+
+Exposes ONE read-only tool, ``web_search``, that searches the open web for a topic, company,
+competitor, or trend and returns titles + URLs. Sources are keyless JSON APIs so it runs in a
+slim container with no API key:
+
+  * Wikipedia opensearch — reference/knowledge results
+  * Hacker News (Algolia) — live discussion / launch / news results
+
+Speaks newline-delimited JSON-RPC 2.0 (the MCP stdio transport) — one JSON message per line —
+matching ``context_runtime.tools.mcp.MCPClient.stdio``. The tool is annotated ``readOnlyHint``
+so, once mounted, the agent-harness ApprovalPolicy lets it run without a gate.
+
+Run:  python -m context_runtime.tools.mcp_servers.web_search
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+_UA = {"User-Agent": "context-runtime-web-search/0.1"}
+_TIMEOUT = 12.0
+
+
+def _get(url: str) -> str:
+    return urllib.request.urlopen(urllib.request.Request(url, headers=_UA), timeout=_TIMEOUT).read().decode("utf-8", "ignore")
+
+
+def _wikipedia(query: str, k: int) -> list[dict]:
+    try:
+        d = json.loads(_get("https://en.wikipedia.org/w/api.php?" + urllib.parse.urlencode(
+            {"action": "opensearch", "search": query, "limit": k, "format": "json"})))
+        return [{"title": t, "url": u, "source": "Wikipedia"} for t, u in zip(d[1], d[3])]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _hackernews(query: str, k: int) -> list[dict]:
+    try:
+        d = json.loads(_get("https://hn.algolia.com/api/v1/search?" + urllib.parse.urlencode(
+            {"query": query, "hitsPerPage": k})))
+        out: list[dict] = []
+        for h in d.get("hits", [])[:k]:
+            title = h.get("title") or h.get("story_title") or ""
+            url = h.get("url") or h.get("story_url") or f"https://news.ycombinator.com/item?id={h.get('objectID', '')}"
+            if title:
+                out.append({"title": title, "url": url, "source": "HackerNews", "points": h.get("points")})
+        return out
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def web_search(query: str, max_results: int = 6) -> str:
+    query = (query or "").strip()
+    if not query:
+        return "Give me something to search for."
+    k = max(1, min(int(max_results or 6), 10))
+    results = (_wikipedia(query, 2) + _hackernews(query, k))[:k]
+    if not results:
+        return f"No web results found for: {query}"
+    lines = [f'Web search — "{query}" ({len(results)} results):']
+    for i, r in enumerate(results, 1):
+        extra = f" · {r['points']} pts" if r.get("points") else ""
+        lines.append(f"{i}. {r['title']} [{r['source']}{extra}]\n   {r['url']}")
+    return "\n".join(lines)
+
+
+_TOOLS = [{
+    "name": "web_search",
+    "description": ("Search the open web (Wikipedia + Hacker News) for information, discussions, or news "
+                    "about a topic, company, competitor, or trend. Returns titles and URLs."),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "the search query"},
+            "max_results": {"type": "integer", "description": "max results to return (default 6)"},
+        },
+        "required": ["query"],
+    },
+    "annotations": {"readOnlyHint": True, "openWorldHint": True},
+}]
+
+
+def _result(rid, result=None, error=None) -> dict:
+    m: dict = {"jsonrpc": "2.0", "id": rid}
+    if error is not None:
+        m["error"] = error
+    else:
+        m["result"] = result
+    return m
+
+
+def _handle(req: dict) -> dict | None:
+    method = req.get("method")
+    rid = req.get("id")
+    params = req.get("params") or {}
+    if method == "initialize":
+        return _result(rid, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                             "serverInfo": {"name": "web-search", "version": "0.1.0"}})
+    if method == "tools/list":
+        return _result(rid, {"tools": _TOOLS})
+    if method == "tools/call":
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        if name != "web_search":
+            return _result(rid, {"content": [{"type": "text", "text": f"unknown tool: {name}"}], "isError": True})
+        try:
+            text = web_search(args.get("query", ""), args.get("max_results", 6))
+            return _result(rid, {"content": [{"type": "text", "text": text}], "isError": False})
+        except Exception as e:  # noqa: BLE001
+            return _result(rid, {"content": [{"type": "text", "text": f"search error: {e}"}], "isError": True})
+    if rid is not None:  # unknown request (notifications have no id → ignored)
+        return _result(rid, error={"code": -32601, "message": f"method not found: {method}"})
+    return None
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception:  # noqa: BLE001
+            continue
+        resp = _handle(req)
+        if resp is not None:
+            sys.stdout.write(json.dumps(resp) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,156 @@
+"""Hermetic MCP adapter tests: real stdio transport + ApprovalPolicy gating."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from context_runtime.tools import ApprovalPolicy, ToolRegistry, ToolResult
+from context_runtime.tools.mcp import MCPClient, mount_mcp
+
+
+FAKE_SERVER = r'''import sys, json
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception:
+            continue
+        rid = req.get("id")
+        meth = req.get("method")
+        params = req.get("params") or {}
+        if meth == "initialize":
+            res = {
+                "jsonrpc": "2.0",
+                "id": rid,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "fake-mcp", "version": "0"},
+                },
+            }
+            print(json.dumps(res, separators=(",", ":")), flush=True)
+            continue
+        if rid is None:
+            # notification (e.g. initialized), no response
+            continue
+        if meth == "tools/list":
+            tools = [
+                {
+                    "name": "web_search",
+                    "description": "search the web",
+                    "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+                {
+                    "name": "echo",
+                    "description": "echo text",
+                    "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}},
+                },
+            ]
+            reply = {"jsonrpc": "2.0", "id": rid, "result": {"tools": tools}}
+            print(json.dumps(reply, separators=(",", ":")), flush=True)
+            continue
+        if meth == "tools/call":
+            nm = (params or {}).get("name", "")
+            args = (params or {}).get("arguments") or {}
+            if nm == "echo":
+                txt = args.get("text", "")
+                if txt == "ERR":
+                    res = {
+                        "isError": True,
+                        "content": [{"type": "text", "text": "failed"}],
+                        "error": "tool error",
+                    }
+                else:
+                    res = {"content": [{"type": "text", "text": "echoed:" + txt}]}
+                print(json.dumps({"jsonrpc": "2.0", "id": rid, "result": res}, separators=(",", ":")), flush=True)
+                continue
+            # web_search or default
+            q = args.get("query", "")
+            res = {"content": [{"type": "text", "text": "web:" + q}]}
+            print(json.dumps({"jsonrpc": "2.0", "id": rid, "result": res}, separators=(",", ":")), flush=True)
+            continue
+        if rid is not None:
+            err = {"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "message": "method not found"}}
+            print(json.dumps(err, separators=(",", ":")), flush=True)
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def _run_with_client_and_registry(policy: ApprovalPolicy | None = None):
+    reg = ToolRegistry(policy=policy)
+    with tempfile.TemporaryDirectory() as td:
+        fake_path = f"{td}/fake_mcp_server.py"
+        with open(fake_path, "w") as f:
+            f.write(FAKE_SERVER)
+        client = MCPClient.stdio([sys.executable, fake_path])
+        try:
+            names = mount_mcp(reg, client)
+            return reg, names, client
+        except Exception:
+            client.close()
+            raise
+
+
+def test_mcp_mount_registers_tools_via_real_stdio():
+    reg, names, client = _run_with_client_and_registry(policy=ApprovalPolicy(mode="bypass"))
+    try:
+        assert set(names) == {"web_search", "echo"}
+        assert set(reg.list()) == {"web_search", "echo"}
+    finally:
+        client.close()
+
+
+def test_mcp_echo_runs_under_bypass_and_returns_text():
+    reg, names, client = _run_with_client_and_registry(policy=ApprovalPolicy(mode="bypass"))
+    try:
+        assert "echo" in reg.list()
+        res = reg.run("echo", {"text": "hi"})
+        assert isinstance(res, ToolResult)
+        assert res.ok is True
+        assert "hi" in res.text
+        assert "echoed" in res.text
+    finally:
+        client.close()
+
+
+def test_mcp_tools_are_gated_by_approval_policy():
+    # default policy (deny_side_effects) blocks side-effecting MCP tool (default_side=True)
+    reg, names, client = _run_with_client_and_registry()
+    try:
+        res = reg.run("echo", {"text": "hi"})
+        assert res.ok is False
+        assert "denied" in (res.error or "")
+    finally:
+        client.close()
+
+    # with allowlist it passes
+    reg2 = ToolRegistry(ApprovalPolicy(mode="allowlist", allow=["echo", "web_search"]))
+    with tempfile.TemporaryDirectory() as td:
+        fake_path = f"{td}/fake_mcp_server.py"
+        with open(fake_path, "w") as f:
+            f.write(FAKE_SERVER)
+        client2 = MCPClient.stdio([sys.executable, fake_path])
+        try:
+            mount_mcp(reg2, client2)
+            res2 = reg2.run("echo", {"text": "allow"})
+            assert res2.ok is True
+            assert "allow" in res2.text
+        finally:
+            client2.close()
+
+
+def test_mcp_iserror_maps_to_toolresult_failure():
+    reg, names, client = _run_with_client_and_registry(policy=ApprovalPolicy(mode="bypass"))
+    try:
+        res = reg.run("echo", {"text": "ERR"})
+        assert res.ok is False
+        assert res.error is not None and "error" in res.error.lower()
+        assert "failed" in (res.text or "")
+    finally:
+        client.close()

--- a/tests/test_web_search_mcp.py
+++ b/tests/test_web_search_mcp.py
@@ -1,0 +1,42 @@
+"""The bundled web_search MCP server + AgentConsole.mount_mcp — the end-to-end proof that an
+app can mount a real MCP tool through the agent-harness registry.
+
+The mount/registration test is hermetic (tools/list is static, no network). The actual search
+test hits keyless public APIs and skips if the network is unavailable.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from context_runtime.integrations.agent_console import AgentConsole, tool
+from context_runtime.tools.mcp import MCPClient
+
+
+def _client() -> MCPClient:
+    return MCPClient.stdio([sys.executable, "-m", "context_runtime.tools.mcp_servers.web_search"])
+
+
+def test_web_search_mounts_as_readonly_tool():
+    console = AgentConsole("X", "A watch monitors a URL.", tools=[tool("noop", "noop", lambda a: {"text": "ok"})])
+    client = _client()
+    try:
+        names = console.mount_mcp(client)
+        assert "web_search" in names
+        assert "web_search" in console._tools                       # visible to classify + dispatch
+        spec = console.registry.get("web_search").spec()
+        assert spec.side_effecting is False                          # readOnlyHint → ungated → runs from chat
+        assert "query" in spec.parameters.get("properties", {})
+    finally:
+        client.close()
+
+
+def test_web_search_returns_results():
+    from context_runtime.tools.mcp_servers.web_search import web_search
+
+    out = web_search("python programming language", 4)
+    if "no web results" in out.lower():
+        pytest.skip("network unavailable / providers returned nothing")
+    assert "results" in out.lower()
+    assert "http" in out.lower()


### PR DESCRIPTION
Brings the v2 branch's Context Runtime work into main.

## What's included
- **AgentConsole** (`integrations/agent_console.py`) — the reusable conversational agent (LLM via a Context Runtime ModelPlugin, redevops-rag-contract grounding, agent-harness gated tools).
- **OpenAICompatibleModel** (`adapters/model_openai.py`) — stdlib OpenAI-compatible ModelPlugin (cost-tiered, on-prem DeepSeek fallback), so slim images run on our model plane without the litellm extra.
- **MCP adapter** (`tools/mcp.py`) — mount external MCP tool servers into the agent-harness `ToolRegistry`, gated by `ApprovalPolicy` (stdio + HTTP transports).
- **Bundled web_search MCP server** (`tools/mcp_servers/web_search.py`) — keyless (Wikipedia + HN/Algolia) read-only search, plus `AgentConsole.mount_mcp()`.
- Tests: `test_mcp.py`, `test_web_search_mcp.py` (hermetic; real stdio + ApprovalPolicy gating).

Merges cleanly over main (PR #1's hipporag gpt-5-mini change preserved; prior turbovec/retrieval/librechat work intact). 6 MCP tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)