### PR TITLE
v4 knowledge-aware routing + real Graphiti temporal binding (source hydration)

### DIFF
--- a/context_runtime/adapters/store_hipporag.py
+++ b/context_runtime/adapters/store_hipporag.py
@@ -98,22 +98,39 @@ class HippoRAGRetriever:
     package and the offline path don't need its (heavy) deps."""
 
     def __init__(self, save_dir: str = ".context_runtime/hipporag", llm_model_name: str = "gpt-5-mini",
-                 embedding_model_name: str = "nvidia/NV-Embed-v2", source: str = "graph"):
+                 embedding_model_name: str = "nvidia/NV-Embed-v2", source: str = "graph",
+                 llm_base_url: str | None = None, embedding_base_url: str | None = None,
+                 llm_api_key: str | None = None):
         self.save_dir = save_dir
         self.llm_model_name = llm_model_name
         self.embedding_model_name = embedding_model_name
         self.source = source
+        # Optional OpenAI-compatible endpoints so HippoRAG's OpenIE + dense retrieval run against a
+        # locally-served LLM / embedding model (e.g. a vLLM NVFP4 endpoint) instead of hosted OpenAI.
+        self.llm_base_url = llm_base_url
+        self.embedding_base_url = embedding_base_url
+        self.llm_api_key = llm_api_key
         self._hr = None
         self._doc_meta: dict[str, dict] = {}   # doc text → {chunk_id, filename}
 
     def _get(self):
         if self._hr is None:
+            import os
             try:
-                from hipporag import HippoRAG  # type: ignore
+                from hipporag import HippoRAG  # type: ignore  # some forks export at package root
+                if not isinstance(HippoRAG, type):             # public OSU repo: got the submodule
+                    from hipporag.HippoRAG import HippoRAG      # type: ignore  # class lives here
             except ImportError as e:  # pragma: no cover
                 raise RuntimeError("HippoRAGRetriever needs: pip install 'context_runtime[hipporag]'") from e
-            self._hr = HippoRAG(save_dir=self.save_dir, llm_model_name=self.llm_model_name,
-                                embedding_model_name=self.embedding_model_name)
+            if self.llm_api_key:                       # HippoRAG/litellm read the key from env
+                os.environ.setdefault("OPENAI_API_KEY", self.llm_api_key)
+            kw = {"save_dir": self.save_dir, "llm_model_name": self.llm_model_name,
+                  "embedding_model_name": self.embedding_model_name}
+            if self.llm_base_url:
+                kw["llm_base_url"] = self.llm_base_url
+            if self.embedding_base_url:
+                kw["embedding_base_url"] = self.embedding_base_url
+            self._hr = HippoRAG(**kw)
         return self._hr
 
     def index(self, path_or_docs) -> dict:
@@ -132,8 +149,11 @@ class HippoRAGRetriever:
     def search(self, query: str, k: int, method: Retrieval = "graph") -> list[Hit]:
         results = self._get().retrieve(queries=[query], num_to_retrieve=k)
         sol = results[0]
-        docs = getattr(sol, "docs", []) or []
-        scores = list(getattr(sol, "doc_scores", []) or [])
+        # docs/doc_scores may be numpy arrays — avoid `or []` (ambiguous truth value on arrays).
+        _docs = getattr(sol, "docs", None)
+        docs = list(_docs) if _docs is not None else []
+        _scores = getattr(sol, "doc_scores", None)
+        scores = list(_scores) if _scores is not None else []
         out = []
         for i, text in enumerate(docs[:k]):
             meta = self._doc_meta.get(text, {"chunk_id": f"hr::{i}", "filename": f"doc-{i}"})

--- a/context_runtime/adapters/store_temporal.py
+++ b/context_runtime/adapters/store_temporal.py
@@ -214,10 +214,15 @@ class GraphitiTemporalRetriever:
                  neo4j_user: str = "neo4j", neo4j_password: str = "graphiti-bench-pw",
                  llm_base_url: str, llm_model: str, llm_api_key: str = "sk-noauth",
                  embed_model: str = "BAAI/bge-large-en-v1.5",
-                 embedder=None, cross_encoder=None, group_id: str = "bench"):
+                 embedder=None, cross_encoder=None, group_id: str = "bench",
+                 hydrate_sources: bool = True):
         """``embedder`` / ``cross_encoder`` accept graphiti ``EmbedderClient`` / ``CrossEncoderClient``
         instances (CR plugin ethos — swap the engines). Left as ``None`` they default to a local
-        CPU sentence-transformers embedder + order-preserving reranker (see ``_make_graphiti_clients``)."""
+        CPU sentence-transformers embedder + order-preserving reranker (see ``_make_graphiti_clients``).
+
+        ``hydrate_sources`` (G1, redevops fork): when the installed ``graphiti_core`` supports source
+        hydration, retrieved edges are backfilled with their raw source turns so hits carry the
+        non-lossy text behind each LLM-extracted fact. Auto-disables against an upstream build."""
         import asyncio
         from graphiti_core import Graphiti  # lazy
         from graphiti_core.llm_client.config import LLMConfig
@@ -225,6 +230,7 @@ class GraphitiTemporalRetriever:
 
         self._loop = asyncio.new_event_loop()
         self.group_id = group_id
+        self.hydrate_sources = hydrate_sources
         self._ep_name: dict[str, str] = {}   # episode uuid → episode name (source id), for provenance
         cfg = LLMConfig(api_key=llm_api_key, model=llm_model, base_url=llm_base_url,
                         small_model=llm_model)
@@ -265,6 +271,19 @@ class GraphitiTemporalRetriever:
             n += 1
         return n
 
+    def _search_edges(self, query: str, k: int, *, search_filter=None):
+        """Run a Graphiti hybrid search, requesting source hydration (G1) when available. Falls back
+        transparently to a plain search if the installed graphiti_core predates the redevops fork."""
+        kw = {"num_results": k, "group_ids": [self.group_id]}
+        if search_filter is not None:
+            kw["search_filter"] = search_filter
+        if self.hydrate_sources:
+            try:
+                return self._run(self._g.search(query, hydrate_sources=True, **kw))
+            except TypeError:
+                self.hydrate_sources = False   # upstream graphiti-core — no hydrate_sources kwarg
+        return self._run(self._g.search(query, **kw))
+
     def _edge_to_hit(self, edge, rank: int, total: int) -> Hit:
         va = getattr(edge, "valid_at", None)
         iva = getattr(edge, "invalid_at", None)
@@ -272,14 +291,22 @@ class GraphitiTemporalRetriever:
         # so temporal retrieval can be scored at source granularity (comparable to doc-level recall).
         ep_uuids = getattr(edge, "episodes", None) or []
         sessions = [self._ep_name[u] for u in ep_uuids if u in self._ep_name]
+        # G1 source hydration: prefer the raw source turns behind the fact (non-lossy). hydrated_text()
+        # falls back to the extracted fact when the edge wasn't/couldn't be hydrated, so this is safe
+        # on both fork and upstream builds. The extracted fact stays available in meta.
+        fact = getattr(edge, "fact", "") or ""
+        hydrate = getattr(edge, "hydrated_text", None)
+        text = hydrate() if callable(hydrate) else fact
         return Hit(
             chunk_id=str(getattr(edge, "uuid", f"e{rank}")),
             filename="graphiti",
-            text=getattr(edge, "fact", "") or "",
+            text=text,
             score=(total - rank) / (total or 1),
             created_at=(va.isoformat() if va else None),
             source="temporal",
             meta={"name": getattr(edge, "name", ""),
+                  "fact": fact,
+                  "hydrated": callable(hydrate) and bool(getattr(edge, "source_episodes", None)),
                   "valid_at": (va.isoformat() if va else None),
                   "invalid_at": (iva.isoformat() if iva else None),
                   "source_sessions": sessions},
@@ -287,7 +314,7 @@ class GraphitiTemporalRetriever:
 
     # ── the RetrieverPlugin seam ──
     def search(self, query: str, k: int = 5, method: Retrieval = "temporal") -> list[Hit]:
-        edges = self._run(self._g.search(query, num_results=k, group_ids=[self.group_id]))
+        edges = self._search_edges(query, k)
         return [self._edge_to_hit(e, i, len(edges)) for i, e in enumerate(edges)]
 
     def as_of(self, query: str, k: int = 5, *, at: "str | datetime",
@@ -306,8 +333,7 @@ class GraphitiTemporalRetriever:
             invalid_at=[[DateFilter(date=atdt, comparison_operator=ComparisonOperator.greater_than)],
                         [DateFilter(comparison_operator=ComparisonOperator.is_null)]],
         )
-        edges = self._run(self._g.search(query, num_results=k, group_ids=[self.group_id],
-                                         search_filter=sf))
+        edges = self._search_edges(query, k, search_filter=sf)
         return [self._edge_to_hit(e, i, len(edges)) for i, e in enumerate(edges)]
 
     def changes(self, query: str = "", *, since: str, until: str, k: int = 20) -> list[dict]:

--- a/context_runtime/adapters/store_temporal.py
+++ b/context_runtime/adapters/store_temporal.py
@@ -123,3 +123,214 @@ class TemporalStore:
     def info(self) -> PluginInfo:
         return PluginInfo(name="temporal", kind="retriever",
                           capabilities=frozenset({"temporal", "retrieval"}))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Optional real backend: Graphiti (bi-temporal knowledge graph over Neo4j).
+#
+# Exposes the SAME RetrieverPlugin seam as ``TemporalStore`` (search / as_of /
+# changes / info), so ``HopRouterRetriever`` treats the two interchangeably —
+# ``method="temporal"`` routes here when a Graphiti backend is wired, and falls
+# back to the dependency-free ``TemporalStore`` otherwise. All ``graphiti_core``
+# imports are lazy so this module keeps importing with no heavy deps installed.
+#
+# Entity/edge extraction uses the configured LLM (point ``llm_base_url`` at the
+# 27B served endpoint); embeddings are computed locally (sentence-transformers),
+# avoiding a second served model. Async graphiti calls are bridged to the sync
+# seam through a private event loop.
+# ─────────────────────────────────────────────────────────────────────────────
+from datetime import datetime, timezone
+
+
+def _as_utc(v: "str | datetime | None") -> datetime:
+    """Coerce a datetime / date string into a tz-aware UTC datetime (Neo4j wants tz-aware).
+    Accepts ISO plus a few common non-ISO shapes (e.g. LongMemEval's '2023/04/10 (Mon) 17:50');
+    unparseable input falls back to 'now' rather than raising."""
+    if v is None or v == "":
+        return datetime.now(timezone.utc)
+    if isinstance(v, datetime):
+        return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+    s = str(v).strip()
+    dt = None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        for fmt in ("%Y/%m/%d (%a) %H:%M", "%Y/%m/%d %H:%M", "%Y-%m-%d %H:%M:%S",
+                    "%Y-%m-%d %H:%M", "%Y/%m/%d", "%Y-%m-%d"):
+            try:
+                dt = datetime.strptime(s, fmt); break
+            except ValueError:
+                continue
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _make_graphiti_clients(embed_model: str):
+    """Build ``(embedder, cross_encoder)`` as real graphiti subclasses — ``GraphitiClients``
+    validates them with ``isinstance``, so duck-typing is rejected. Defined lazily so this
+    module still imports with neither graphiti_core nor sentence-transformers installed.
+
+    Embedder is CPU-pinned (venv torch lacks Blackwell sm_120 kernels, and it keeps the GPU
+    free for the served LLMs). A 1024-dim model matches graphiti's default ``EMBEDDING_DIM``
+    so the Neo4j vector index dimensions line up. Reranker preserves candidate order to avoid
+    a per-search LLM rerank call.
+    """
+    from graphiti_core.embedder.client import EmbedderClient
+    from graphiti_core.cross_encoder.client import CrossEncoderClient
+    from sentence_transformers import SentenceTransformer
+
+    class _STEmbedder(EmbedderClient):
+        def __init__(self, name):
+            self._m = SentenceTransformer(name, device="cpu")
+
+        async def create(self, input_data):
+            # Contract (matches graphiti's OpenAIEmbedder): return ONE flat vector (list[float]),
+            # even when handed a single-element list. Batches go through create_batch.
+            text = input_data if isinstance(input_data, str) else (
+                (list(input_data)[0] if input_data else ""))
+            return self._m.encode([text], normalize_embeddings=True)[0].tolist()
+
+        async def create_batch(self, input_data_list):
+            return [v.tolist() for v in self._m.encode(list(input_data_list), normalize_embeddings=True)]
+
+    class _OrderReranker(CrossEncoderClient):
+        async def rank(self, query, passages):
+            n = len(passages) or 1
+            return [(p, (n - i) / n) for i, p in enumerate(passages)]
+
+    return _STEmbedder(embed_model), _OrderReranker()
+
+
+class GraphitiTemporalRetriever:
+    """Real bi-temporal retriever: graphiti-core's Neo4j KG behind the temporal slot.
+
+    Drop-in replacement for :class:`TemporalStore` when the full Graphiti engine is
+    wanted (LLM-extracted entities/edges, hybrid semantic+graph search, point-in-time
+    ``as_of`` via Neo4j-side temporal filters) rather than the stdlib token store.
+    """
+
+    def __init__(self, *, neo4j_uri: str = "bolt://localhost:7687",
+                 neo4j_user: str = "neo4j", neo4j_password: str = "graphiti-bench-pw",
+                 llm_base_url: str, llm_model: str, llm_api_key: str = "sk-noauth",
+                 embed_model: str = "BAAI/bge-large-en-v1.5",
+                 embedder=None, cross_encoder=None, group_id: str = "bench"):
+        """``embedder`` / ``cross_encoder`` accept graphiti ``EmbedderClient`` / ``CrossEncoderClient``
+        instances (CR plugin ethos — swap the engines). Left as ``None`` they default to a local
+        CPU sentence-transformers embedder + order-preserving reranker (see ``_make_graphiti_clients``)."""
+        import asyncio
+        from graphiti_core import Graphiti  # lazy
+        from graphiti_core.llm_client.config import LLMConfig
+        from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+
+        self._loop = asyncio.new_event_loop()
+        self.group_id = group_id
+        self._ep_name: dict[str, str] = {}   # episode uuid → episode name (source id), for provenance
+        cfg = LLMConfig(api_key=llm_api_key, model=llm_model, base_url=llm_base_url,
+                        small_model=llm_model)
+        if embedder is None or cross_encoder is None:
+            d_emb, d_ce = _make_graphiti_clients(embed_model)
+            embedder = embedder or d_emb
+            cross_encoder = cross_encoder or d_ce
+        self._g = Graphiti(
+            neo4j_uri, neo4j_user, neo4j_password,
+            llm_client=OpenAIGenericClient(config=cfg),
+            embedder=embedder, cross_encoder=cross_encoder,
+        )
+        self._run(self._g.build_indices_and_constraints())
+
+    def _run(self, coro):
+        return self._loop.run_until_complete(coro)
+
+    # ── ingest ──
+    def index(self, episodes) -> int:
+        """Ingest episodes (bi-temporal). Each: dict(body, reference_time, name?, source_description?)."""
+        from graphiti_core.nodes import EpisodeType  # lazy
+        n = 0
+        for e in episodes:
+            name = e.get("name", f"ep{n}")
+            res = self._run(self._g.add_episode(
+                name=name,
+                episode_body=e["body"],
+                source_description=e.get("source_description", ""),
+                reference_time=_as_utc(e.get("reference_time")),
+                source=EpisodeType.text,
+                group_id=self.group_id,
+            ))
+            # provenance: remember which source (session) this episode came from, so retrieved
+            # edges can be traced back to their source and scored at source granularity.
+            ep = getattr(res, "episode", None)
+            if ep is not None and getattr(ep, "uuid", None):
+                self._ep_name[ep.uuid] = name
+            n += 1
+        return n
+
+    def _edge_to_hit(self, edge, rank: int, total: int) -> Hit:
+        va = getattr(edge, "valid_at", None)
+        iva = getattr(edge, "invalid_at", None)
+        # provenance: map the edge's source episode uuids back to their source names (session ids),
+        # so temporal retrieval can be scored at source granularity (comparable to doc-level recall).
+        ep_uuids = getattr(edge, "episodes", None) or []
+        sessions = [self._ep_name[u] for u in ep_uuids if u in self._ep_name]
+        return Hit(
+            chunk_id=str(getattr(edge, "uuid", f"e{rank}")),
+            filename="graphiti",
+            text=getattr(edge, "fact", "") or "",
+            score=(total - rank) / (total or 1),
+            created_at=(va.isoformat() if va else None),
+            source="temporal",
+            meta={"name": getattr(edge, "name", ""),
+                  "valid_at": (va.isoformat() if va else None),
+                  "invalid_at": (iva.isoformat() if iva else None),
+                  "source_sessions": sessions},
+        )
+
+    # ── the RetrieverPlugin seam ──
+    def search(self, query: str, k: int = 5, method: Retrieval = "temporal") -> list[Hit]:
+        edges = self._run(self._g.search(query, num_results=k, group_ids=[self.group_id]))
+        return [self._edge_to_hit(e, i, len(edges)) for i, e in enumerate(edges)]
+
+    def as_of(self, query: str, k: int = 5, *, at: "str | datetime",
+              known_at: "str | datetime | None" = None) -> list[Hit]:
+        """Point-in-time: edges valid at ``at`` (valid_from ≤ at < valid_to), Neo4j-side filtered."""
+        from graphiti_core.search.search_filters import (  # lazy
+            SearchFilters, DateFilter, ComparisonOperator)
+        atdt = _as_utc(at)
+        # inner list = OR: a fact is live at `at` when it hadn't been invalidated yet
+        # (invalid_at > at) OR is still valid (invalid_at IS NULL). Without the null branch,
+        # still-current facts (the common case) would be wrongly excluded.
+        # SearchFilters nesting: outer list = OR-groups, inner list = AND within a group.
+        # "not yet invalidated" = (invalid_at > at) OR (invalid_at IS NULL) → two OR-groups.
+        sf = SearchFilters(
+            valid_at=[[DateFilter(date=atdt, comparison_operator=ComparisonOperator.less_than_equal)]],
+            invalid_at=[[DateFilter(date=atdt, comparison_operator=ComparisonOperator.greater_than)],
+                        [DateFilter(comparison_operator=ComparisonOperator.is_null)]],
+        )
+        edges = self._run(self._g.search(query, num_results=k, group_ids=[self.group_id],
+                                         search_filter=sf))
+        return [self._edge_to_hit(e, i, len(edges)) for i, e in enumerate(edges)]
+
+    def changes(self, query: str = "", *, since: str, until: str, k: int = 20) -> list[dict]:
+        """"What changed, and when?" — edges that began/ended validity in ``[since, until)``."""
+        lo, hi = _as_utc(since), _as_utc(until)
+        edges = self._run(self._g.search(query or "*", num_results=max(k * 3, 30),
+                                         group_ids=[self.group_id]))
+        out: list[dict] = []
+        for e in edges:
+            va, iva = getattr(e, "valid_at", None), getattr(e, "invalid_at", None)
+            if va and lo <= va < hi:
+                out.append({"at": va.isoformat(), "change": "began", "fact": getattr(e, "fact", "")})
+            if iva and lo <= iva < hi:
+                out.append({"at": iva.isoformat(), "change": "ended", "fact": getattr(e, "fact", "")})
+        out.sort(key=lambda c: c["at"])
+        return out[:k]
+
+    def info(self) -> PluginInfo:
+        return PluginInfo(name="graphiti", kind="retriever",
+                          capabilities=frozenset({"temporal", "retrieval", "graph"}))
+
+    def close(self):
+        try:
+            self._run(self._g.close())
+        finally:
+            self._loop.close()

--- a/context_runtime/planner/intent.py
+++ b/context_runtime/planner/intent.py
@@ -24,6 +24,10 @@ class RuleIntentAnalyzer:
             confidence = min(1.0, confidence + 0.1)
         # v4: the first decision — which knowledge representation is this question even about?
         representation = representations.classify(bucket, goal.text, entities)
+        # a positive representation HINT (not the bucket default) is a strong signal — raise confidence
+        # so the hybrid LLM head trusts it for free instead of spending a model call to re-check.
+        if representation != "document" and representation != representations.BUCKET_REPRESENTATION.get(bucket, "document"):
+            confidence = max(confidence, 0.85)
         return Intent(
             bucket=bucket,
             entities=entities,

--- a/context_runtime/planner/llm_intent.py
+++ b/context_runtime/planner/llm_intent.py
@@ -1,0 +1,125 @@
+"""LLM-backed intent analysis for representation routing — the hybrid, confidence-gated head.
+
+The v4 planner (``classify → constrain → learn``) is validated, but its *shipped* head — the keyword
+``RuleIntentAnalyzer`` — is the bottleneck: it scores well on EXPLICIT cues yet ~0.00 on IMPLICIT
+multi-hop / temporal intent (a question like "Who is the spouse of the Green performer?" carries no
+"multi-hop"/"related to" string, so it defaults to ``document`` and the graph engine is never routed to).
+
+This module adds an LLM head, **gated by confidence** so it stays off the hot path: run the cheap
+keyword analyzer first; only fall to the LLM when the keyword head is *unsure* — i.e. it defaulted to
+``document`` (or an ``unknown``/``conceptual`` bucket) or reported low confidence. That is exactly the
+implicit-intent case. Explicit cues ("as of", "how many", "related to", …) are handled for free by the
+keyword head, so ~all cost stays on the cheap path. This reuses the same confidence seam that
+``planner/candidates.py`` already keys its widening on.
+
+``OpenAICompatModel`` is a stdlib OpenAI-compatible chat client (no SDK dep); point it at any served
+model (a vLLM NVFP4 endpoint, a hosted API, …).
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+
+from . import representations
+from .intent import RuleIntentAnalyzer
+from ..types import Intent
+
+_SYS = (
+    "You are a retrieval router. Read the question and reply with EXACTLY ONE word naming the "
+    "knowledge representation needed to answer it:\n"
+    "  document   — a single fact lookup answerable from one passage\n"
+    "  graph      — needs multi-hop reasoning chaining several linked entities/facts\n"
+    "  temporal   — needs time-ordered or point-in-time facts from a history/conversation\n"
+    "  analytical — needs a STRUCTURED data store with a known schema/tables (SQL, MongoDB or "
+    "Elasticsearch): a lookup, filter, join or aggregate — e.g. counts/rankings, 'records where …', "
+    "'from the <table>'\n"
+    "  code       — needs reasoning over source code / a codebase\n"
+    "  multimodal — needs an image/screenshot/diagram\n"
+    "Reply with only one of: document, graph, temporal, analytical, code, multimodal.")
+
+_VALID = ("temporal", "graph", "analytical", "code", "multimodal", "document")
+
+# When the LLM corrects the representation, re-align the intent bucket so BUCKET_TIERS / strategy /
+# verify follow it (candidates.py already constrains the *method* by representation; this fixes the
+# *model tier* selection too). Only representations with a dedicated bucket are mapped.
+_REP_TO_BUCKET = {"graph": "multi_hop", "temporal": "temporal", "code": "code_reasoning"}
+
+
+class OpenAICompatModel:
+    """Minimal stdlib OpenAI-compatible chat client for the intent head (no SDK dependency)."""
+
+    def __init__(self, base_url: str, model: str, *, api_key: str = "sk-noauth",
+                 timeout: float = 60.0, disable_thinking: bool = True):
+        self.base = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self.timeout = timeout
+        self.disable_thinking = disable_thinking
+
+    def classify(self, text: str) -> str | None:
+        payload = {"model": self.model, "temperature": 0, "max_tokens": 6,
+                   "messages": [{"role": "system", "content": _SYS},
+                                {"role": "user", "content": text}]}
+        if self.disable_thinking:
+            payload["chat_template_kwargs"] = {"enable_thinking": False}
+        req = urllib.request.Request(self.base + "/chat/completions",
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json",
+                       "Authorization": f"Bearer {self.api_key}"}, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as r:
+                d = json.load(r)
+            out = ((d.get("choices") or [{}])[0].get("message") or {}).get("content", "") or ""
+        except Exception:  # noqa: BLE001 — network/parse failure ⇒ defer to the keyword head
+            return None
+        out = out.strip().lower()
+        for rep in _VALID:
+            if rep in out:
+                return rep
+        return None
+
+
+class HybridIntentAnalyzer:
+    """Keyword-first, LLM-on-doubt intent analyzer.
+
+    ``analyze(goal) -> Intent`` — drop-in for ``RuleIntentAnalyzer`` in ``ContextRuntime(intent=…)``.
+    The LLM head fires only when the keyword head is unsure (defaulted to ``document`` / uncertain
+    bucket / confidence below ``confidence_floor``); otherwise the cheap keyword verdict stands.
+    When the LLM overrides the representation, confidence is raised to ``override_confidence`` so the
+    candidate generator constrains to the new representation instead of widening.
+    """
+
+    def __init__(self, model: OpenAICompatModel, *, base=None,
+                 confidence_floor: float = 0.6, override_confidence: float = 0.85,
+                 unsure_buckets: tuple[str, ...] = ("unknown", "conceptual")):
+        self.model = model
+        self.base = base or RuleIntentAnalyzer()
+        self.confidence_floor = confidence_floor
+        self.override_confidence = override_confidence
+        self.unsure_buckets = unsure_buckets
+        # routing-cost ledger: `escalated` = model calls (the per-query intent-routing overhead to
+        # weigh against a model's built-in context management), `overrides` = calls that changed the route.
+        self.stats = {"analyzed": 0, "escalated": 0, "overrides": 0}
+
+    def _unsure(self, intent: Intent) -> bool:
+        # Trust a confident positive representation (graph/temporal/analytical/…) for FREE — spend a
+        # model call only on the blind-spot default `document`, or a genuinely low-confidence verdict.
+        if intent.representation != "document":
+            return intent.confidence < self.confidence_floor
+        return intent.bucket in self.unsure_buckets or intent.confidence < self.confidence_floor
+
+    def analyze(self, goal) -> Intent:
+        self.stats["analyzed"] += 1
+        intent = self.base.analyze(goal)
+        if not self._unsure(intent):
+            return intent                      # explicit cue → trust the free keyword head
+        self.stats["escalated"] += 1           # a model call — the intent-routing cost line
+        rep = self.model.classify(goal.text)
+        if rep is None or rep == intent.representation:
+            return intent                      # LLM unavailable or agrees → keep keyword verdict
+        self.stats["overrides"] += 1
+        bucket = _REP_TO_BUCKET.get(rep, intent.bucket)   # re-align tiers/strategy to the new representation
+        return Intent(bucket=bucket, entities=intent.entities, risk=intent.risk,
+                      normalized=intent.normalized,
+                      confidence=max(intent.confidence, self.override_confidence),
+                      representation=rep)

--- a/context_runtime/planner/representations.py
+++ b/context_runtime/planner/representations.py
@@ -25,7 +25,13 @@ REPRESENTATION_OF: dict[Retrieval, KnowledgeRepresentation] = {
     "community": "community",
     "temporal": "temporal",
     "code": "code",
-    "sql": "analytical", "logs": "analytical", "api": "analytical",
+    # the analytical representation = a STRUCTURED data store. `sql` for relational; `mongo` / `elastic`
+    # where SQL is not applicable; `api`/`logs` for other structured feeds. A deployment binds a
+    # RetrieverPlugin under whichever method matches its DB; the planner routes here, the bound plugin
+    # executes the query. Unbound methods are pruned by the cost model (the `hybrid` fallback catches
+    # a store that isn't wired).
+    "sql": "analytical", "mongo": "analytical", "elastic": "analytical",
+    "logs": "analytical", "api": "analytical",
     "image": "multimodal", "colpali": "multimodal", "video": "multimodal",
 }
 
@@ -58,6 +64,15 @@ HINT_RULES: list[tuple[re.Pattern, KnowledgeRepresentation]] = [
                 r"top\s+\d+|rank(ed|ing)?|group\s+by|distribution\s+of|trend|breakdown|"
                 r"month[- ]over[- ]month|year[- ]over[- ]year|\bmrr\b|\barr\b|conversion\s+rate)\b",
                 re.I), "analytical"),
+    # structured-store lookups/filters against a KNOWN schema (relational or NoSQL/search) — not just
+    # aggregates. A deployment with a plugged-in DB routes these to its SQL/Mongo/Elastic retriever.
+    (re.compile(r"\b(select\s+.+\s+from\b|\bjoin\b|\bsql\b|\bnosql\b|"
+                r"(records?|rows?|documents?|entries?|orders?|customers?|users?|invoices?|"
+                r"transactions?|accounts?)\s+(where|with|whose|that\s+have)\b|"
+                r"(from|in|query|querying)\s+(the\s+)?[\w-]+\s+(table|collection|index|database|db|schema)\b|"
+                r"(table|collection|index|schema)\s+(named|called|for|containing)\b|"
+                r"(columns?|fields?|attributes?)\s+(of|in|from|for)\b|"
+                r"filter(ed)?\s+by\b|look\s*up\s+\w+\s+by\b)", re.I), "analytical"),
     (re.compile(r"\b(screenshot|screen\s?shot|image|photo|picture|diagram|figure|chart\s+image|"
                 r"scanned|scan\s+of|receipt|invoice\s+image|whiteboard|slide)\b", re.I), "multimodal"),
     (re.compile(r"\b(as\s+of|point[- ]in[- ]time|what\s+changed|history\s+of|superseded|"

--- a/context_runtime/types.py
+++ b/context_runtime/types.py
@@ -145,7 +145,9 @@ class Plan:
 
 Retrieval = Literal[
     "vector", "bm25", "hybrid", "graph", "community", "image", "colpali", "video",
-    "sql", "api", "logs", "file", "code", "temporal",
+    # structured-store methods (the `analytical` representation): relational + the NoSQL/search
+    # backends a deployment may plug in where SQL is not applicable.
+    "sql", "mongo", "elastic", "api", "logs", "file", "code", "temporal",
 ]
 
 # The knowledge *representation* a retrieval method operates over. The planner's first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,13 @@ litellm = ["litellm>=1.40"]
 rag = ["redevops-rag @ git+https://github.com/redevops-io/redevops-rag.git"]
 # Multi-hop graph retrieval (knowledge graph + Personalized PageRank).
 hipporag = ["hipporag @ git+https://github.com/redevops-io/HippoRAG.git"]
+# Bi-temporal graph retrieval (the `temporal` method) — real Graphiti KG over Neo4j.
+# Pinned to the redevops fork for G1 source hydration (recovers the raw source turns
+# behind each lossy LLM-extracted fact); neo4j ships with graphiti-core.
+graphiti = [
+    "graphiti-core @ git+https://github.com/redevops-io/graphiti.git@redevops/g1-source-hydration",
+    "sentence-transformers>=3.0",
+]
 # Semantic (embedding) retrieval + hybrid BM25⊕semantic fusion — deterministic ONNX
 # embeddings (no torch) that bridge synonyms/morphology lexical BM25 can't. The runtime
 # falls back to pure BM25 when this isn't installed.


### PR DESCRIPTION
## v4 knowledge-aware routing + real Graphiti temporal binding (source hydration)

The v4-increment for the knowledge-aware routing rerun (bigger NVFP4 models, larger datasets). Now **rebased onto `main`** so it merges cleanly — the same four commits also live on the canonical **`v4`** branch (`460c5ef`).

> Recommended: **Squash and merge** (matches the `"vN → main"` convention of #1/#2/#5). After squash, `main`'s tree equals `v4`'s.

### Commits
- **planner(v4): structured-store routing + confidence-gated hybrid LLM intent head** — `analytical` representation spans structured stores (adds `mongo`/`elastic` + structured-lookup hint rules); `intent.py` confidence boost on a representation hint; new `HybridIntentAnalyzer` (`llm_intent.py`), a confidence-gated LLM head for implicit multi-hop/temporal intent, pointable at any served NVFP4 endpoint.
- **adapters: real Graphiti temporal binding + HippoRAG local NVFP4 endpoints** — `GraphitiTemporalRetriever` over `graphiti_core` (lazy; stdlib `TemporalStore` stays the fallback); HippoRAG gains optional OpenAI-compatible endpoints for locally-served models.
- **adapters(G1): wire GraphitiTemporalRetriever to source hydration** — hits carry the raw source turns behind each lossy fact via `edge.hydrated_text()`, transparent fallback on upstream graphiti-core. Pairs with `redevops-io/graphiti#1`.
- **deps: pin graphiti-core to the redevops fork** — the `graphiti` extra pins the G1 source-hydration build.

### Conflict reconciliation
`main` already carried v4 as a squash (#5) plus the `gpt-5-mini` default (#1), while this branch forked v4 one commit earlier. Rebasing onto `main` reconciled the one real overlap in `store_hipporag.py`: **`gpt-5-mini` default is kept** alongside the new NVFP4 endpoint params (both survive).

### Depends on
`graphiti_core` installed from the fork (`redevops-io/graphiti#1`) for hydration to engage; against upstream graphiti-core the adapter auto-disables hydration and behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)