### PR TITLE
docs: fix benchmark stub, stale agentic-os framing, test count, Go parity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,7 +59,7 @@ contracts.
 | Context Runtime plugin | Repo | What it provides |
 |---|---|---|
 | **Retriever** | [`redevops-rag`](https://github.com/redevops-io/redevops-rag) (single-hop) + [`HippoRAG`](https://github.com/redevops-io/HippoRAG) (multi-hop) | DuckDB dense + BM25 → **RRF** → rerank for single-hop; knowledge graph + Personalized PageRank for multi-hop. The planner routes between them per query. |
-| **Router** | native (`context_runtime/adapters/model_litellm.py`) | Capability-tiered routing (local → cheap → premium), per-task budget, fallback up tiers. *Context Runtime is the control plane — routing is native; prototyped in the now-retired agentic-os.* |
+| **Router** | native (`context_runtime/adapters/model_litellm.py`) | Capability-tiered routing (local → cheap → premium), per-task budget, fallback up tiers. *Context Runtime is the control plane — routing is native; prototyped in agentic-os (now the public v6 cockpit).* |
 | **Policy / Tools** | native (`context_runtime/tools/`, `context_runtime/policy/`) | ApprovalPolicy + dangerous-pattern scan, human-in-the-loop gates, append-only audit log. *Absorbed from agentic-os `safety.py`/`control_plane`.* |
 | **Agent Scheduler** | [`sidekick`](https://github.com/redevops-io/sidekick) `orchestrator.py`, `planner.py`, `worktree.py` | DAG decomposition → bounded parallel waves → isolated worktrees → acceptance checks → merge. Validated 5.4× speedup, 0 conflicts. |
 | **Compression (structural) + Token Budget** | `sidekick` `context_budget.py`, `memory.py` | `clip()` + `reduce_transcript()` (tiered, dedup). |
@@ -463,7 +463,9 @@ observability: {exporter: openllmetry, sink: langfuse, traces: true}
 
 ---
 
-## 9. Repository structure (revised)
+## 9. Repository structure (target)
+
+> This is the **target** layout — several entries are roadmap-gated (CP-SAT optimizer, mixture reasoner, OPA/Presidio policy, prompt cache) and not all present yet; see [ROADMAP.md](ROADMAP.md) for what has shipped.
 
 ```
 context_runtime/

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,12 +1,12 @@
 # Benchmarks
 
-> **Consolidated.** All Context Runtime benchmark results now live in one canonical document:
-> **[`BENCHMARKS.md`](https://github.com/redevops-io/context-runtime/blob/main/BENCHMARKS.md)** — the
-> comparable **capability ladder** (v1→v5 on a single mixed stream, end-to-end accuracy + tokens),
-> then a **drill-down per version** (v1→v2 calibration in Python & Go, v3 drift, v4 knowledge
-> routing, v5 DIVER reasoning retrieval), the standalone studies (heterogeneous shards, chat-memory,
-> parallel fusion, tenants/governance), and full methodology.
+Context Runtime's benchmark results live in two places you can inspect directly:
 
-Everything that used to live in this file, in `docs/BENCHMARK-REPORT.md`, and in
-`docs/BENCHMARKS-v3-preliminary.md` has been merged into that one document. The runnable examples
-are unchanged — reproduce any result with `PYTHONPATH=. python examples/<name>.py`.
+- **[`benchmarks.html`](./benchmarks.html)** — the rendered results: the capability ladder and
+  per-version drill-downs (v1→v2 calibration in Python & Go, v3 drift, v4 knowledge routing,
+  v5 DIVER reasoning retrieval), the standalone studies (heterogeneous shards, chat-memory,
+  parallel fusion, tenants/governance), and methodology.
+- The **[Benchmarks section of the README](./README.md#benchmarks)** — the headline numbers.
+
+Every result is **reproducible** from the runnable examples:
+`PYTHONPATH=. python examples/<name>.py`.

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -54,19 +54,19 @@ the *arms* (what to choose) and the *reward* (how to score it) are app-specific.
 | Tenant | Decision point Context Runtime optimizes | Reward (the app's own metric) | Status |
 |---|---|---|---|
 | **sidekick** (coding agent) | which skills to recall · bundle size · token budget | acceptance rate · first-try · tokens | **built, green** — drop-in for `SkillStore`; 67% vs 33% naive baseline |
-| **redevops-rag** (retrieval) | `pool · limit · vector_threshold · recency · keyword priors · rerank` per query intent | retrieval quality − efficiency penalty | **built, green** — `ContextRuntimeRetrieverTuner`; 0.773 vs 0.323 fixed default |
+| **redevops-rag** (retrieval) | `pool · limit · vector_threshold · recency · keyword priors · rerank` per query intent | retrieval quality − efficiency penalty | **built, green** — `ContextRuntimeRetrieverTuner`; 0.780 vs 0.428 fixed default |
 | **edge-sentinel** (SOC) | which sources to pull per alert (CrowdSec · threat-intel · EDR) | correct verdict − source cost | **built, green** — tool-using + approval-gated; 0.900 vs 0.800 always-full |
-| **business modules** (billing · support · BI · compliance …) | which sources/cores to query · which model tier | task success · cost-per-good-answer | next — each becomes a tenant with a goal + a metric |
+| **business modules** (billing · support · BI · compliance …) | which sources/cores to query · which model tier | task success · cost-per-good-answer | **now built** — each is a tenant with a goal + a metric (see the full fleet) |
 
 These prove the pattern generalizes across very different decision types: sidekick
 chooses among **discrete strategies**, redevops-rag tunes **numeric knobs**,
 edge-sentinel selects **sources/tools with side effects**. Same bandit, same
 cost-model, same wrap. That is the whole bet.
 
-**Context Runtime *is* the control plane.** It supersedes the earlier `agentic-os` fleet
-controller — the routing, approval/safety, and audit-log capabilities prototyped there
-now live natively in Context Runtime (`adapters/model_litellm.py`, `tools/`,
-`observability/`). The business modules that the old fleet ran become **tenants**: each
+**Context Runtime *is* the control plane.** It absorbs the earlier `agentic-os` fleet-controller logic — the routing, approval/safety,
+and audit-log capabilities prototyped there now live natively in Context Runtime (agentic-os
+itself continues as the public v6 mission cockpit) (`adapters/model_litellm.py`, `tools/`,
+`observability/`). The business modules become **tenants**: each
 gets a goal, a metric, and a learned policy, instead of a hand-wired controller.
 
 ## Why this is a more durable position

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ with an approval-gated audit trail) and **trace exporters** (`context_runtime/ob
 exporters.py` — JSONL offline, or Langfuse / OpenLLMetry-OTel when the extras are
 installed).
 
-> Status: **runnable reference implementation — Python and Go at feature parity.** Runs fully
+> Status: **runnable reference implementation. Python is the source of truth; the Go port tracks it closely.** Runs fully
 > offline with stub models; real bindings are wired and lazy-imported: LiteLLM models, and
 > [redevops-rag](https://github.com/redevops-io/redevops-rag) / DuckDB / Postgres retrieval
 > (BM25 · dense · hybrid · graph-PPR · community · sharded routing · cross-modal). Beyond the
@@ -146,7 +146,7 @@ The six plugin seams and their initial slice; several "real bindings" below are 
 
 ## Also shipped
 
-Beyond the initial slice, in both the Python source-of-truth and the Go port (feature parity):
+Beyond the initial slice, in both the Python source-of-truth and the Go port (which tracks it):
 
 - **Retrieval as a routable capability** — BM25 · dense (fastembed ONNX) · hybrid (RRF) · graph
   (Personalized-PageRank multi-hop) · community · **sharded coverage routing** for heterogeneous
@@ -182,5 +182,5 @@ The decision layer is thin; the substrate is reused. See:
 ## Test
 
 ```bash
-pip install -e ".[dev]" && pytest      # 360+ tests; test_conformance.py == SPEC §10
+pip install -e ".[dev]" && pytest      # 325 tests; test_conformance.py == SPEC §10
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,7 +74,7 @@ model calls than hand-rolled RAG.
 **Assemble (reuse, don't build):**
 - Retrieval → **redevops-rag** behind `StoreAdapter`
 - Providers → **LiteLLM** (deletes the hand-written `providers/` dir)
-- Routing policy → **native** cost-tiered router (prototyped in the now-retired agentic-os)
+- Routing policy → **native** cost-tiered router (prototyped in agentic-os (now the public v6 cockpit))
 - Structural compression + token clipping → **sidekick** `context_budget.py`
 - Semantic compression → **LLMLingua-2**
 - Memory → **mem0** (simple store; Graphiti deferred to v0.3)

--- a/eval/context_runtime_eval.md
+++ b/eval/context_runtime_eval.md
@@ -1,6 +1,6 @@
 # Context Runtime RAG Evaluation Report
 
-_Run date: 2024-?? (python eval/context_runtime_eval.py)_
+_Reproduce: `python eval/context_runtime_eval.py`_
 
 ## Python backend results
 


### PR DESCRIPTION
Audit of the maintained docs (README already fixed in #13): repoint the empty self-referential BENCHMARKS.md to benchmarks.html + examples; correct 'retired agentic-os' framing (it's the live v6 cockpit) in ARCHITECTURE/ROADMAP/POSITIONING; 360+ -> 325 tests; soften Go 'feature parity' per GO_PORT; refresh POSITIONING numbers; mark ARCHITECTURE §9 as the target layout; drop an eval placeholder date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)