### PR TITLE
Serving surface: Bedrock /v1 upstream + read-route auth + MCP retrieval tool (§2.4–2.5)

### DIFF
--- a/context_runtime/control_plane/app.py
+++ b/context_runtime/control_plane/app.py
@@ -1345,15 +1345,27 @@ def librechat_ingest(req: LcIngestReq) -> dict:
     return {"ingested": _tenant_for(req.model).ingest(req.path)}
 
 
-@app.post("/librechat/retrieve")
-def librechat_retrieve(req: LcRetrieveReq) -> dict:
-    """Plan + retrieve context for a request using the learned strategy (no judging yet)."""
-    tenant = _tenant_for(req.model)
-    ctx = tenant.retrieve(req.request)
+def retrieve_bundle(tenant, request: str) -> dict:
+    """Plan + retrieve a context bundle for ``request`` using the tenant's learned strategy.
+
+    The single source of truth for "give me an optimal context bundle", shared by the HTTP route and
+    the MCP tool (control_plane/mcp_server.py) so an AgentCore Gateway / Strands agent gets exactly
+    what /librechat/retrieve returns — routed KR, cost-optimal method, hits + assembled context + an
+    EXPLAIN-able plan id."""
+    ctx = tenant.retrieve(request)
     return {"request": ctx.request, "strategy": ctx.strategy.key,
             "method": ctx.strategy.method, "final_k": ctx.strategy.final_k,
             "hits": _hits_json(ctx.hits), "context": ctx.context, "plan_id": ctx.plan.id,
-            "suggestion": tenant.suggest(req.request)}
+            "suggestion": tenant.suggest(request)}
+
+
+@app.post("/librechat/retrieve", dependencies=[Depends(require_api_key)])
+def librechat_retrieve(req: LcRetrieveReq) -> dict:
+    """Plan + retrieve context for a request using the learned strategy (no judging yet).
+
+    API-key gated (§3.2): this returns corpus content, so before an agent calls it over the network
+    set CONTEXT_RUNTIME_API_KEY. Unset → open (localhost-only deployments), unchanged."""
+    return retrieve_bundle(_tenant_for(req.model), req.request)
 
 
 class LcCompareReq(BaseModel):
@@ -1362,7 +1374,7 @@ class LcCompareReq(BaseModel):
     model: str | None = None   # the corpus the Query Board is inspecting (per selected chat model)
 
 
-@app.post("/librechat/compare")
+@app.post("/librechat/compare", dependencies=[Depends(require_api_key)])
 def librechat_compare(req: LcCompareReq) -> dict:
     """Retrieval transparency: run every method (bm25/vector/hybrid/community/graph) side by
     side and report what the learned policy chose + served. Powers the LibreChat comparison
@@ -1370,7 +1382,7 @@ def librechat_compare(req: LcCompareReq) -> dict:
     return _tenant_for(req.model).compare(req.request, k=max(1, min(req.k, 10)))
 
 
-@app.post("/librechat/explain")
+@app.post("/librechat/explain", dependencies=[Depends(require_api_key)])
 def librechat_explain(req: LcCompareReq) -> dict:
     """EXPLAIN (the DB EXPLAIN-ANALYZE analogue): why the runtime retrieved what it did — every
     candidate arm with its learned value + quality/cost decomposition, the per-method retrieval
@@ -1540,9 +1552,57 @@ def v1_models() -> dict:
         for tid in _TENANTS]}
 
 
+# ── Bedrock as a first-class /v1 upstream (§2.5) ──────────────────────────────────────────────────
+# Point the shim at Bedrock instead of an OpenAI-compatible endpoint: set CR_UPSTREAM_PROVIDER=aws
+# (and optionally CR_BEDROCK_MODEL / AWS_REGION). Then ANY agent pointed at CR's /v1 gets
+# context-optimized Bedrock calls with EXPLAIN + learning, zero client change. Built once, lazily;
+# tests inject a model via _set_bedrock_upstream().
+_BEDROCK_UPSTREAM = None
+_BEDROCK_UPSTREAM_BUILT = False
+
+
+def _set_bedrock_upstream(model) -> None:  # test seam
+    global _BEDROCK_UPSTREAM, _BEDROCK_UPSTREAM_BUILT
+    _BEDROCK_UPSTREAM, _BEDROCK_UPSTREAM_BUILT = model, True
+
+
+def _bedrock_upstream_model():
+    global _BEDROCK_UPSTREAM, _BEDROCK_UPSTREAM_BUILT
+    if _BEDROCK_UPSTREAM_BUILT:
+        return _BEDROCK_UPSTREAM
+    _BEDROCK_UPSTREAM_BUILT = True
+    if os.getenv("CR_UPSTREAM_PROVIDER", "").lower() == "aws" or os.getenv("CR_BEDROCK_MODEL"):
+        try:
+            from ..providers import get_provider
+            model_id = os.getenv("CR_BEDROCK_MODEL", "amazon.nova-lite-v1:0")
+            cost = float(os.getenv("CR_BEDROCK_COST_PER_1K", "0") or 0)
+            prov = get_provider("aws", region=os.getenv("AWS_REGION"),
+                                model_tiers=[("chat", model_id, cost)])
+            _BEDROCK_UPSTREAM = prov.model()
+        except Exception:  # noqa: BLE001 — misconfigured/absent boto3 → fall back to OpenAI/offline path
+            _BEDROCK_UPSTREAM = None
+    return _BEDROCK_UPSTREAM
+
+
+def _forward_via_bedrock(model, messages: list[dict], req: ChatCompletionReq) -> tuple[str, dict, str]:
+    from ..types import ModelRequest
+    system = next((m["content"] for m in messages if m["role"] == "system"), None)
+    convo = tuple({"role": m["role"], "content": m["content"]} for m in messages if m["role"] != "system")
+    floor = int(os.getenv("CR_UPSTREAM_MAX_TOKENS", "2048"))
+    res = model.complete(ModelRequest(messages=convo, system=system,
+                                      max_tokens=max(req.max_tokens or 0, floor)))
+    usage = {"prompt_tokens": res.prompt_tokens, "completion_tokens": res.completion_tokens,
+             "total_tokens": res.prompt_tokens + res.completion_tokens}
+    return res.text, usage, res.model
+
+
 def _forward_to_upstream(messages: list[dict], req: ChatCompletionReq) -> tuple[str, dict, str]:
-    """Forward the augmented messages to an OpenAI-compatible upstream. Returns
-    (answer, usage, model_name). Falls back to a grounded extractive answer offline."""
+    """Forward the augmented messages to an upstream. Returns (answer, usage, model_name).
+    Precedence: Bedrock (if CR_UPSTREAM_PROVIDER=aws) → OpenAI-compatible (CR_UPSTREAM_BASE_URL) →
+    a grounded extractive answer offline."""
+    bedrock = _bedrock_upstream_model()
+    if bedrock is not None:
+        return _forward_via_bedrock(bedrock, messages, req)
     if not _UPSTREAM_BASE:
         # offline / no upstream: answer straight from the retrieved context (grounded stub)
         ctx_preamble = next((m["content"] for m in messages if m["role"] == "system"), "")

--- a/context_runtime/control_plane/mcp_server.py
+++ b/context_runtime/control_plane/mcp_server.py
@@ -1,0 +1,49 @@
+"""Context Runtime as an MCP tool — the context-serving sidecar for AgentCore / Strands agents (§2.4).
+
+An AgentCore **Gateway** *is* MCP, and Strands agents consume MCP tools — so exposing "give me an
+optimal context bundle" as an MCP tool lets an agent running on the AWS stack call Context Runtime as
+a first-class tool, riding AWS's own tool plane instead of a bespoke integration. The tool returns the
+exact bundle `/librechat/retrieve` does (routed knowledge representation, cost-optimal method, hits +
+assembled context, an EXPLAIN-able plan id), drawn from whatever arms the deployment wired — Bedrock
+KB, OpenSearch, local hybrid.
+
+fastmcp is an optional dep (like the agentic-os MCP server); it's imported lazily in ``build_mcp`` so
+this module imports without it. Run:  ``python -m context_runtime.control_plane.mcp_server``
+"""
+from __future__ import annotations
+
+import os
+
+
+def retrieve_context(request: str, model: str | None = None, *, tenant_resolver=None) -> dict:
+    """Core tool logic (fastmcp-free, so it's unit-testable). ``tenant_resolver(model) -> tenant``
+    defaults to the control plane's; injectable for tests."""
+    if tenant_resolver is None:
+        from .app import _tenant_for as tenant_resolver  # noqa: N813
+    from .app import retrieve_bundle
+    return retrieve_bundle(tenant_resolver(model), request)
+
+
+def build_mcp():
+    """Construct the FastMCP server exposing the retrieval tool (lazy fastmcp import)."""
+    from fastmcp import FastMCP
+
+    mcp = FastMCP("context-runtime")
+
+    @mcp.tool()
+    def retrieve_context_tool(request: str, model: str | None = None) -> dict:
+        """Return a cost-optimal context bundle for `request`: the chosen knowledge representation +
+        retrieval method, the ranked hits, the assembled context string, and a plan id you can
+        EXPLAIN. `model` selects the corpus/tenant (optional)."""
+        return retrieve_context(request, model)
+
+    return mcp
+
+
+def main() -> None:  # pragma: no cover — process entrypoint
+    build_mcp().run(transport="streamable-http", host="0.0.0.0",
+                    port=int(os.getenv("CR_MCP_PORT", "8081")))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_serving_surface.py
+++ b/tests/test_serving_surface.py
@@ -1,0 +1,77 @@
+"""Serving surface (§2.4 auth + MCP tool, §2.5 Bedrock /v1 upstream).
+
+Uses the control-plane extra + monkeypatch so module globals never leak between tests.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from context_runtime.control_plane import app as appmod
+from context_runtime.control_plane import mcp_server
+from context_runtime.types import ModelResult
+
+client = TestClient(appmod.app)
+
+
+# ── §2.4 auth on the read routes (opt-in: enforced only when a key is set) ───────────────────────
+def test_retrieve_open_when_no_key_set(monkeypatch):
+    monkeypatch.delenv("CONTEXT_RUNTIME_API_KEY", raising=False)
+    monkeypatch.delenv("AGENTIC_OS_API_KEY", raising=False)
+    r = client.post("/librechat/retrieve", json={"request": "hello"})
+    assert r.status_code != 401         # unchanged default: open on localhost
+
+
+@pytest.mark.parametrize("route", ["/librechat/retrieve", "/librechat/compare", "/librechat/explain"])
+def test_read_routes_require_key_when_set(monkeypatch, route):
+    monkeypatch.setenv("CONTEXT_RUNTIME_API_KEY", "secret")
+    assert client.post(route, json={"request": "x"}).status_code == 401           # missing header
+    ok = client.post(route, json={"request": "x"}, headers={"X-API-Key": "secret"})
+    assert ok.status_code != 401                                                  # correct header passes auth
+
+
+# ── §2.5 Bedrock as the /v1 upstream ─────────────────────────────────────────────────────────────
+class FakeBedrockModel:
+    def __init__(self):
+        self.seen = None
+
+    def complete(self, req):
+        self.seen = req
+        return ModelResult(text="bedrock says hi", model="amazon.nova-lite-v1:0", tier="chat",
+                           prompt_tokens=7, completion_tokens=3)
+
+
+def test_forward_prefers_bedrock_when_configured(monkeypatch):
+    fake = FakeBedrockModel()
+    monkeypatch.setattr(appmod, "_BEDROCK_UPSTREAM", fake)
+    monkeypatch.setattr(appmod, "_BEDROCK_UPSTREAM_BUILT", True)
+    messages = [{"role": "system", "content": "RETRIEVED CONTEXT: ..."}, {"role": "user", "content": "hi"}]
+    req = appmod.ChatCompletionReq(messages=[appmod.ChatMessage(role="user", content="hi")])
+    answer, usage, model = appmod._forward_to_upstream(messages, req)
+    assert answer == "bedrock says hi"
+    assert usage["total_tokens"] == 10 and model == "amazon.nova-lite-v1:0"
+    # system prompt is lifted into ModelRequest.system; conversation excludes the system turn
+    assert fake.seen.system == "RETRIEVED CONTEXT: ..."
+    assert all(m["role"] != "system" for m in fake.seen.messages)
+    assert fake.seen.max_tokens >= 2048       # the shim's max-tokens floor is applied
+
+
+def test_bedrock_upstream_lazy_builder_off_by_default(monkeypatch):
+    monkeypatch.setattr(appmod, "_BEDROCK_UPSTREAM", None)
+    monkeypatch.setattr(appmod, "_BEDROCK_UPSTREAM_BUILT", False)
+    monkeypatch.delenv("CR_UPSTREAM_PROVIDER", raising=False)
+    monkeypatch.delenv("CR_BEDROCK_MODEL", raising=False)
+    assert appmod._bedrock_upstream_model() is None      # not configured → no Bedrock, use other paths
+
+
+# ── §2.4 the MCP tool logic (fastmcp-free core) ──────────────────────────────────────────────────
+def test_mcp_retrieve_context_returns_bundle():
+    ctx = SimpleNamespace(request="q", context="CTX", hits=[],
+                          strategy=SimpleNamespace(key="hybrid:cheap", method="hybrid", final_k=5),
+                          plan=SimpleNamespace(id="p1"))
+    tenant = SimpleNamespace(retrieve=lambda r: ctx, suggest=lambda r: "try graph")
+    out = mcp_server.retrieve_context("q", tenant_resolver=lambda m: tenant)
+    assert out["method"] == "hybrid" and out["plan_id"] == "p1"
+    assert out["context"] == "CTX" and out["suggestion"] == "try graph" and out["hits"] == []


### PR DESCRIPTION
Stacked on #15 (provider adapters). Turns roadmap §2.4–2.5 into tested code — the control-plane
serving surface so agents on the AWS stack use Context Runtime as their context layer.

## §2.5 — Bedrock as a first-class `/v1` upstream
`_forward_to_upstream` precedence is now **Bedrock → OpenAI-compatible → offline**. Set
`CR_UPSTREAM_PROVIDER=aws` (optionally `CR_BEDROCK_MODEL` / `AWS_REGION`) and any agent pointed at CR's
`/v1/chat/completions` gets context-optimized **Bedrock** calls with EXPLAIN + learning, zero client
change. Built lazily via the AWS provider; injectable for tests. Off by default → unchanged behaviour.

## §2.4 — auth on the read routes
`/librechat/retrieve`, `/compare`, `/explain` now depend on `require_api_key` — a **no-op unless**
`CONTEXT_RUNTIME_API_KEY` is set (backward compatible; set it before exposing retrieval to agents over
the network). Retrieve logic extracted into `retrieve_bundle()` as the single source of truth.

## §2.4 — MCP retrieval tool (`control_plane/mcp_server.py`)
Exposes "give me an optimal context bundle" as an **MCP tool**, so an AgentCore **Gateway** (which is
MCP) or a Strands agent calls CR retrieval on AWS's own tool plane. Core logic is fastmcp-free and
unit-tested; fastmcp is lazy-imported only to serve.

## Tests
7 new (auth open/closed across the three routes, Bedrock-preferred forward with system-lift +
max-tokens floor, lazy-builder-off-by-default, MCP tool bundle). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)