### PR TITLE
Consolidate v4 reasoning plane into main (superset) + runtime data-source licensing

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,12 +1,168 @@
 # Benchmarks
 
-> **Consolidated.** All Context Runtime benchmark results now live in one canonical document:
-> **[`BENCHMARKS.md`](https://github.com/redevops-io/context-runtime/blob/main/BENCHMARKS.md)** — the
-> comparable **capability ladder** (v1→v5 on a single mixed stream, end-to-end accuracy + tokens),
-> then a **drill-down per version** (v1→v2 calibration in Python & Go, v3 drift, v4 knowledge
-> routing, v5 DIVER reasoning retrieval), the standalone studies (heterogeneous shards, chat-memory,
-> parallel fusion, tenants/governance), and full methodology.
+Every result below is produced by a runnable example in [`examples/`](./examples) — no
+invented numbers. Reproduce with `PYTHONPATH=. python examples/<name>.py`.
 
-Everything that used to live in this file, in `docs/BENCHMARK-REPORT.md`, and in
-`docs/BENCHMARKS-v3-preliminary.md` has been merged into that one document. The runnable examples
-are unchanged — reproduce any result with `PYTHONPATH=. python examples/<name>.py`.
+---
+
+## v1 → v2, measured in both runtimes (headline)
+
+**`examples/consolidated_benchmark.py`** — runs the *same* seeded, ground-truth retrieval
+simulation in the Python source-of-truth **and** the Go port, and merges the results into one
+table. v2 adds the DSpark-inspired upgrades: calibrated per-passage relevance folded into the
+reward, grounded abstention, and the load-aware expensive-stage sizer. Reproduce with
+`PYTHONPATH=. python examples/consolidated_benchmark.py` (add `--html out.html` for the site card).
+
+| Metric | Py v1 | Py v2 | Δ | Go v1 | Go v2 | Δ |
+| --- | --- | --- | --- | --- | --- | --- |
+| Learned-policy precision | 67.6% | 82.2% | ▲ +14.6 pts | 84.6% | 95.9% | ▲ +11.3 pts |
+| Abstention recall (unanswerable caught) | 0.0% | 100.0% | ▲ +100.0 pts | 0.0% | 100.0% | ▲ +100.0 pts |
+| False-abstain rate (answerable dropped) | 0.0% | 0.0% | — | 0.0% | 0.0% | — |
+| Expensive-stage depth (passages) | 8.00 | 3.00 | ▼ −62% | 8.00 | 3.00 | ▼ −63% |
+| Precision after the sizer | 37.5% | 100.0% | ▲ +62.5 pts | 37.5% | 100.0% | ▲ +62.5 pts |
+
+_40-seed average; precision headlined at β=0.9 (the calibration-trust knob; shipped default 0.5).
+Go is an **independent re-implementation on identical methodology** — the two runtimes agree
+directionally on every effect, which is the point: the policy improvement is a property of the
+design, not of one language's simulation. Absolute precision differs because each runtime uses its
+own strategy set (the achievable ceiling differs), but both show a double-digit lift, full
+abstention that v1 lacks, and a ~62% depth cut with precision rising to 100%._
+
+---
+
+## Retrieval over heterogeneous personal data (financial × medical)
+
+> **Now live** as the **"Context Runtime · Mixed"** model on chat.redevops.io — the same
+> coverage-routed sharding, served from `CR_TENANTS=…mixed=shards(finance:/corpus,medical:/medical)`.
+> The live demo's medical shard is the public **PubMedQA** corpus (`deploy/medical/`, ~3.3k
+> passages); the measurement below used the smaller **16-note curated collision set** from
+> `examples/heterogeneous_shards.py` (built to maximize the vocabulary overlap the result turns on).
+
+**`examples/heterogeneous_shards.py`** — the interesting, non-obvious one.
+
+A real user's local files are a mix of very different data. This runs against **real
+FinanceBench 10-K pages** plus a small **medical corpus deliberately built to collide on
+vocabulary** — words that mean different things in each domain: *discharge* (hospital vs
+debt), *statement* (patient vs financial), *balance* (fluid vs sheet), *chronic* / *acute*
+(condition vs distress), *liability*.
+
+Three strategies over the same data — a flat mixed index, sharded + RRF fusion, and
+sharded + coverage routing — measured on 8 medical probes over **3000 financial pages + 16
+clinical notes**:
+
+| Strategy | Medical recall | Cross-domain noise (top-5) |
+|---|---|---|
+| flat mixed index | 8/8 | **2.5** finance docs / query |
+| sharded + RRF fuse | 8/8 | **2.9** *(fusion makes it worse)* |
+| sharded + **coverage-routed** | 8/8 | **0.0** |
+
+**The surprise:** it is *not* a burial problem. BM25's length-normalization keeps the short,
+focused clinical note at **rank #1** in every strategy — recall is 8/8 across the board. The
+real failure is **context pollution**: a collision query like *"discharge summary"* drags
+10-K *"discharge of liability"* pages into the top-k, and naive RRF fusion (which pulls from
+every shard) injects **more** cross-domain noise, not less.
+
+**Coverage routing** fixes it. Instead of comparing raw BM25 scores across shards — which is
+meaningless when one shard has 16 docs and another has 3000 — it scores each shard by its best
+hit's **query-term coverage** (a corpus-statistics-independent signal) and fuses only the
+shard(s) the query actually belongs to. That cut cross-domain noise **22 → 0 docs across the 8
+queries, bidirectionally** (financial queries return zero medical docs too), with recall
+intact.
+
+The routing threshold (`route_margin`) is exactly the kind of policy a Context Runtime bandit
+learns per query bucket — see the chat-memory tenant below.
+
+```
+corpus: 3000 financial 10-K pages + 16 medical notes  (k=5)
+
+MEDICAL probes  (recall of the right note  |  cross-domain noise in top-5)
+  strategy                recall   avg-noise
+  mixed flat index        8/8      2.50 fin-docs/query
+  sharded + RRF fuse      8/8      2.88 fin-docs/query
+  sharded + routed        8/8      0.00 fin-docs/query
+
+verdict: coverage routing cut cross-domain noise 22 -> 0 docs across 8 medical
+         queries while keeping recall 8/8.
+```
+
+Backends: the shards are `InMemoryStore` by default; `adapters/store_duckdb.py` gives the same
+retrieval over a persistent DuckDB `fts` index (one file per shard / per user's local data),
+and `adapters/store_postgres.py` over a Postgres `tsvector` index — the *same* flat-vs-routed
+result holds on all three.
+
+---
+
+## 3-index chat memory — learning which index to read
+
+**`examples/chat_memory.py`** — an Elastic-Atlas-style agent memory with three recall modes
+(**recency / semantic / entity**) exposed as one `RetrieverPlugin`. A per-bucket
+ε-greedy bandit learns which single index to read per query bucket, from `value − read-cost`.
+
+| | Context Runtime (learned) | baseline (read all three) | lift |
+|---|---|---|---|
+| reward | **1.23** | −1.70 | **+2.93** |
+
+Learned policy: `followup → recency`, `factual → semantic`, `entity → entity`. Reading all
+three indices always answers but pays the full read cost; CR learns the cheap decisive index
+per bucket. The offline example simulates the reward; `ChatMemoryTenant.record_feedback()` is
+the live path (a real thumbs / task-success signal).
+
+---
+
+## Parallel sharded fusion
+
+**`examples/parallel_fusion.py`** — the scheduler fans a query out to N shards concurrently,
+then RRF-fuses the union (Polars when installed, else a pure-Python fallback that is
+byte-identical).
+
+| | value |
+|---|---|
+| shards | 6 |
+| parallel fan-out vs sequential | **5.8× faster** (wall-clock = slowest shard, not the sum) |
+| fusion top-K parallel vs sequential | **identical** |
+
+Polars parallelizes the *fusion*; the concurrent fan-out (optionally planned by the
+`SchedulerPlugin`) is the separate win.
+
+## Calibrated, load-aware retrieval (v1 vs v2) — the DSpark-inspired additions
+
+**`examples/dspark_calibration_bench.py`** — a seeded simulation of the LibreChat
+self-learning loop over a stub corpus with **ground-truth per-passage relevance**, so we
+can score what was actually served. The per-query judge models the real heuristic judge: it
+scores **term coverage / recall**, so it rewards dumping more passages and is blind to
+precision — the coarse signal the per-passage calibrated `P(relevant)` corrects. Because the
+v2 features are opt-in, *v2 with them off is byte-for-byte v1* — the A/B is a flag toggle in
+one process. Each effect is isolated (precision measured on answerable, non-abstained only).
+
+The reward comparison is **seed-averaged over 40 seeds**: a single run is dominated by
+bandit exploration luck (every high-coverage arm ties on the coverage judge, so which one
+the policy locks onto is random), so a lone run can read anywhere from +0 to +30 pts. The
+systematic effect grows with how much the reward trusts calibrated relevance over the coarse
+judge — the `beta` sweep:
+
+| effect | v1 baseline | v2 | delta |
+|---|---|---|---|
+| **reward** — served true-precision, β=0.5 | 67.6% | 68.9% | **+1.3 pts** |
+| **reward** — served true-precision, β=0.7 | 67.6% | 74.3% | **+6.7 pts** |
+| **reward** — served true-precision, β=0.9 | 67.6% | 82.2% | **+14.6 pts** |
+| **abstention** — unanswerable queries caught | 0% (can't) | 100% | — |
+| **abstention** — answerable wrongly dropped | — | 0.0% | — |
+| **sizer** — passages to the expensive stage (deep k=8 arm) | 8.00 | 3.00 | **−62%** |
+| **sizer** — precision of that served set | 38% | 100% | pruned the low-relevance tail |
+
+```
+(1) reward     v1 67.6%  →  v2 68.9% (β0.5) / 74.3% (β0.7) / 82.2% (β0.9)   [40-seed avg]
+(2) abstention v2 catches 100% of unanswerable queries, 0% false abstentions (v1 cannot)
+(3) sizer      deep k=8 arm: 8.00 → 3.00 passages (−62%), precision 38% → 100%
+```
+
+**Why each moves:** (1) the coarse coverage judge makes judge-only (v1) chase deep,
+low-precision arms; the reward now blends the mean calibrated relevance of the *served*
+passages (`reward_beta`), and the more it trusts that over the judge, the better the learned
+policy — monotone in β (β=0.3 is actually −2 pts, so the live default is 0.5). (2) a
+calibrated `P(relevant)` floor lets the runtime say "not enough context" and skip the
+upstream call — impossible on v1, whose scores aren't probabilities. (3) the sizer admits
+passages by DSpark's cumulative survival product and stops when it decays, so a deep arm's
+irrelevant tail never reaches synthesis. All default off; `v1`/`v2` git branches capture the
+same toggle for an out-of-process A/B. (2) and (3) are deterministic; only (1) needs seed
+averaging.

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -14,3 +14,6 @@ Most evals/examples in this repo use small synthetic, self-authored corpora (no 
 
 ## Synthetic / self-authored (no external data)
 - eval/context_runtime_eval.py and most examples/ build small hand-written corpora inline. The Russian medical-lab PDFs referenced in eval/context_runtime_eval.md are a private/personal corpus, not a public dataset, and are not redistributed.
+
+## How this data is used
+These datasets are used solely to develop and benchmark the Context Runtime software itself (internal R&D and regression testing of stack improvements). They are NOT redistributed, NOT embedded in or shipped with the product, and NOT part of any customer deployment. Context Runtime customers apply the software to their own data under their own data licenses.

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -1,0 +1,16 @@
+# Data sources & licensing
+
+Most evals/examples in this repo use small synthetic, self-authored corpora (no external data). Two demos use public datasets, downloaded on demand into gitignored dirs (we ship the downloader, not the data):
+
+## FinanceBench (Patronus AI) - deploy/financebench/
+- Source: https://github.com/patronus-ai/financebench - expert Q&A over real SEC 10-K/10-Q filings.
+- License: CC-BY-4.0. Attribution: Patronus AI.
+- Used by: examples/heterogeneous_shards.py.
+
+## PubMedQA (Jin et al., EMNLP 2019) - deploy/medical/
+- Source: https://github.com/pubmedqa/pubmedqa - expert-labeled biomedical Q&A over PubMed abstracts.
+- License: MIT.
+- Citation: Jin et al., "PubMedQA: A Dataset for Biomedical Research Question Answering," EMNLP 2019.
+
+## Synthetic / self-authored (no external data)
+- eval/context_runtime_eval.py and most examples/ build small hand-written corpora inline. The Russian medical-lab PDFs referenced in eval/context_runtime_eval.md are a private/personal corpus, not a public dataset, and are not redistributed.

--- a/context_runtime/adapters/model_openai.py
+++ b/context_runtime/adapters/model_openai.py
@@ -75,6 +75,9 @@ class OpenAICompatibleModel:
         # chat_template_kwargs.enable_thinking; harmless to others that ignore unknown extras.
         if req.thinking is not None:
             payload["chat_template_kwargs"] = {"enable_thinking": bool(req.thinking)}
+        # Self-consistency arm samples at temperature > 0 so its K traces diverge (None = adapter default).
+        if req.temperature is not None:
+            payload["temperature"] = float(req.temperature)
         request = urllib.request.Request(
             tier.base_url + "/chat/completions",
             data=json.dumps(payload).encode(),

--- a/context_runtime/adapters/model_openai.py
+++ b/context_runtime/adapters/model_openai.py
@@ -71,6 +71,10 @@ class OpenAICompatibleModel:
         payload: dict = {"model": tier.model, "messages": messages, tok_key: req.max_tokens}
         if req.tools:
             payload["tools"] = list(req.tools)
+        # Generation-strategy thinking toggle: reasoning models (Qwen/Nemotron) read
+        # chat_template_kwargs.enable_thinking; harmless to others that ignore unknown extras.
+        if req.thinking is not None:
+            payload["chat_template_kwargs"] = {"enable_thinking": bool(req.thinking)}
         request = urllib.request.Request(
             tier.base_url + "/chat/completions",
             data=json.dumps(payload).encode(),

--- a/context_runtime/adapters/store_diver.py
+++ b/context_runtime/adapters/store_diver.py
@@ -59,6 +59,12 @@ class DiverTemporalRetriever:
     def index(self, path: str) -> dict[str, Any]:
         from redevops_rag.ingest import ingest as _ingest
 
+        # A persisted DuckDB store (db_path is a file) survives restarts: skip the expensive bge
+        # embed when it is already populated, and only rebuild the (cheap) in-process FTS index.
+        # This is what keeps a warm, pre-built index from re-embedding a large corpus every boot.
+        if self._store.count() > 0:
+            self._store.reindex_fts()
+            return {"reused_chunks": self._store.count()}
         res = _ingest(self._store, self._embedder, path)
         self._store.reindex_fts()
         n = self._store.count()

--- a/context_runtime/adapters/store_diver.py
+++ b/context_runtime/adapters/store_diver.py
@@ -47,11 +47,18 @@ class DiverTemporalRetriever:
                  db_path: str = ":memory:") -> None:
         # Lazy imports: redevops-rag (sentence-transformers/torch) is an opt-in [rag] extra,
         # so importing this module must not require it — only constructing the arm does.
-        from redevops_rag.embed import Embedder
+        import os
+
+        from redevops_rag.embed import make_embedder
         from redevops_rag.store import Store
         from redevops_rag.temporal import TemporalReasoningRetriever
 
-        self._embedder = Embedder(embed_model)          # bge-small-en by default
+        # Encoder is backend-selectable (REDEVOPS_RAG_EMBED_BACKEND, or CR_NEMOTRON=1 → nemotron): bge
+        # by default, Nemotron-3-Embed-8B when flagged — so DIVER can be benched over either encoder.
+        # embed_model only overrides the bge model name (Nemotron is picked by URL/env, not model path).
+        _backend = os.environ.get("REDEVOPS_RAG_EMBED_BACKEND", "bge").strip().lower()
+        self._embedder = (make_embedder("bge", model_name=embed_model)
+                          if _backend == "bge" and embed_model else make_embedder(_backend))
         self._store = Store(self._embedder, db_path)
         self._plug = TemporalReasoningRetriever(reason_llm, pool=pool, n_subqueries=n_subqueries)
 

--- a/context_runtime/adapters/store_semantic.py
+++ b/context_runtime/adapters/store_semantic.py
@@ -21,11 +21,41 @@ _embedder = None
 _embedder_tried = False
 
 
+def _nemotron_selected() -> bool:
+    """Nemotron-3-Embed-8B chosen as the vector encoder — via CR_NEMOTRON=1 or
+    REDEVOPS_RAG_EMBED_BACKEND=nemotron. Opt-in; the default stays the cheap ONNX model."""
+    if os.getenv("CR_NEMOTRON", "").strip().lower() in ("1", "true", "yes", "on"):
+        return True
+    return os.getenv("REDEVOPS_RAG_EMBED_BACKEND", "").strip().lower() in ("nemotron", "nemo", "nemotron-embed")
+
+
+class _NemotronONNXShim:
+    """Adapts redevops-rag's :class:`NemotronEmbedder` (``.encode`` over an HTTP /v1/embeddings
+    endpoint) to the fastembed ``.embed(texts) -> iterable[vector]`` interface this module expects, so
+    the vector/hybrid arm can run on Nemotron with no other change. Queries get Nemotron's instruction
+    prefix; documents are embedded raw (``_embed`` is called per-chunk at index time and per-query at
+    search time — both symmetric here, matching how the ONNX path treats them)."""
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def embed(self, texts):
+        return self._inner.encode(list(texts))
+
+
 def _get_embedder():
-    """Lazily load the ONNX embedder once; None if fastembed/model is unavailable."""
+    """Lazily load the embedder once; None if unavailable (→ pure BM25). The Nemotron HTTP arm is
+    picked when flagged, else the cheap fastembed ONNX model."""
     global _embedder, _embedder_tried
     if not _embedder_tried:
         _embedder_tried = True
+        if _nemotron_selected():
+            try:
+                from redevops_rag.embed import NemotronEmbedder
+                _embedder = _NemotronONNXShim(NemotronEmbedder())
+            except Exception:
+                _embedder = None
+            return _embedder
         try:
             from fastembed import TextEmbedding
             _embedder = TextEmbedding(_MODEL_NAME)

--- a/context_runtime/control_plane/app.py
+++ b/context_runtime/control_plane/app.py
@@ -964,7 +964,10 @@ def _maybe_diver_temporal(tenant_id: str = ""):
     try:
         from ..adapters.store_diver import DiverTemporalRetriever
         db_dir = os.getenv("CR_DIVER_DB_DIR", "").strip()
-        db_path = os.path.join(db_dir, f"diver_{tenant_id or 'default'}.duckdb") if db_dir else ":memory:"
+        db_path = ":memory:"
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)   # DuckDB won't create a missing parent dir
+            db_path = os.path.join(db_dir, f"diver_{tenant_id or 'default'}.duckdb")
         return DiverTemporalRetriever(_make_reason_llm(), db_path=db_path)
     except Exception:
         return None

--- a/context_runtime/control_plane/app.py
+++ b/context_runtime/control_plane/app.py
@@ -951,15 +951,21 @@ def _make_reason_llm():
     return _reason
 
 
-def _maybe_diver_temporal():
+def _maybe_diver_temporal(tenant_id: str = ""):
     """The DIVER temporal RetrieverPlugin when CR_DIVER=1, else None. Import + construction are
     guarded: a deployment without the [rag] extra (sentence-transformers/bge) just gets no arm,
-    and HopRouterRetriever falls its `temporal` route back to single-hop."""
+    and HopRouterRetriever falls its `temporal` route back to single-hop.
+
+    When CR_DIVER_DB_DIR is set, each tenant's bge store persists to
+    ``<dir>/diver_<tenant>.duckdb`` — so a pre-built index survives restarts and the corpus is
+    embedded once, not on every boot (see DiverTemporalRetriever.index)."""
     if os.getenv("CR_DIVER", "").strip().lower() not in ("1", "true", "yes", "on"):
         return None
     try:
         from ..adapters.store_diver import DiverTemporalRetriever
-        return DiverTemporalRetriever(_make_reason_llm())
+        db_dir = os.getenv("CR_DIVER_DB_DIR", "").strip()
+        db_path = os.path.join(db_dir, f"diver_{tenant_id or 'default'}.duckdb") if db_dir else ":memory:"
+        return DiverTemporalRetriever(_make_reason_llm(), db_path=db_path)
     except Exception:
         return None
 
@@ -1218,7 +1224,7 @@ def _parse_tenants_spec(spec: str) -> list[tuple[str, str, str]]:
     return out
 
 
-def _build_lc_retriever(shards_spec: str = ""):
+def _build_lc_retriever(shards_spec: str = "", tenant_id: str = ""):
     """A fresh LibreChat retriever built the same way the single-tenant path builds `_lc_retriever`
     (hybrid→HopRouter base, optional coverage-routed shards, optional multimodal wrap) — one per
     tenant so each corpus is indexed independently."""
@@ -1237,7 +1243,7 @@ def _build_lc_retriever(shards_spec: str = ""):
             from ..adapters.store_router import HopRouterRetriever
             retr = HopRouterRetriever(single_hop=retr, graph=SimGraphRetriever([]),
                                       community=CommunityRetriever([]),
-                                      temporal=_maybe_diver_temporal())
+                                      temporal=_maybe_diver_temporal(tenant_id))
         except Exception:
             pass
     if shards_spec:
@@ -1297,7 +1303,7 @@ _tenants_spec = os.getenv("CR_TENANTS", "").strip()
 if _tenants_spec:
     _parsed = _parse_tenants_spec(_tenants_spec)
     for _tid, _cdir, _sspec in _parsed:
-        _t = _make_tenant(_build_lc_retriever(_sspec), tenant_id=_tid)
+        _t = _make_tenant(_build_lc_retriever(_sspec, tenant_id=_tid), tenant_id=_tid)
         if _cdir and os.path.isdir(_cdir):
             try:
                 _t.ingest(_cdir)   # single-corpus tenants index at startup; shards self-index

--- a/context_runtime/control_plane/app.py
+++ b/context_runtime/control_plane/app.py
@@ -921,6 +921,15 @@ def vibex_scoreboard() -> dict:
 # ──────────────────────────── LibreChat — self-learning retrieval (LLM-judged) ────────────────────────────
 from ..integrations.librechat import LibreChatTenant   # noqa: E402
 
+# ── Nemotron embedding arm (opt-in, CR_NEMOTRON=1) ────────────────────────────────────────
+# Nemotron-3-Embed-8B (RTEB #1, 4096-d) as the vector encoder, served over an OpenAI-compatible
+# /v1/embeddings endpoint (NIM/vLLM on GPU). CR_NEMOTRON=1 is the friendly switch — normalize it to
+# the redevops-rag backend var so BOTH encoder arms agree: the DIVER arm (store_diver → make_embedder,
+# reads REDEVOPS_RAG_EMBED_BACKEND) and the vector/hybrid arm (store_semantic._nemotron_selected).
+# Opt-in + heavier than the cheap bge default — enable it to A/B, not blindly (see benchmarks/eval_embedders.py).
+if os.getenv("CR_NEMOTRON", "").strip().lower() in ("1", "true", "yes", "on"):
+    os.environ.setdefault("REDEVOPS_RAG_EMBED_BACKEND", "nemotron")
+
 # ── DIVER temporal-reasoning arm (opt-in, CR_DIVER=1) ─────────────────────────────────────
 # redevops-rag's diver_search wired as the HopRouter `temporal` slot: query-expand → hybrid →
 # listwise rerank, driven by the reasoning upstream (KIMI). Needs the [rag] extra

--- a/context_runtime/explain.py
+++ b/context_runtime/explain.py
@@ -40,6 +40,21 @@ def render_explain(exp: dict) -> str:
         out.append(f"  {mark} {c['key']:<20} reward {b['value']:.3f} (n={b['n']}){qtxt}{served}")
         out.append(f"      └ {c['reason']}")
 
+    # ── generation strategy (the answer plane) ──
+    gen = exp.get("generation")
+    if gen and gen.get("enabled"):
+        out.append(_section(f"generation — strategy ladder for {gen['bucket']} (learned)"))
+        for i, c in enumerate(gen["candidates"]):
+            mark = "►" if c.get("entry_point") else " "
+            b = c["bandit"]
+            think = "think" if c["thinking"] else "no-think"
+            entry = "  ← entry point" if c.get("entry_point") else ""
+            out.append(f"  {mark} {c['strategy']:<12} {think} · {c['max_tokens']}t · cost≈{c['cost_units']:.1f}"
+                       f"   reward {b['value']:.3f} (n={b['n']}){entry}")
+    elif gen is not None:
+        out.append(_section("generation"))
+        out.append(f"  {gen.get('note', 'legacy single_shot')}")
+
     # ── retrieval trace ──
     out.append(_section("retrieval — every method, calibrated P(relevant)"))
     for method, rows in exp["retrieval"].items():

--- a/context_runtime/explain.py
+++ b/context_runtime/explain.py
@@ -43,7 +43,7 @@ def render_explain(exp: dict) -> str:
     # ── generation strategy (the answer plane) ──
     gen = exp.get("generation")
     if gen and gen.get("enabled"):
-        out.append(_section(f"generation — strategy ladder for {gen['bucket']} (learned)"))
+        out.append(_section(f"reasoning — strategy ladder for {gen['bucket']} (learned)"))
         for i, c in enumerate(gen["candidates"]):
             mark = "►" if c.get("entry_point") else " "
             b = c["bandit"]
@@ -51,6 +51,15 @@ def render_explain(exp: dict) -> str:
             entry = "  ← entry point" if c.get("entry_point") else ""
             out.append(f"  {mark} {c['strategy']:<12} {think} · {c['max_tokens']}t · cost≈{c['cost_units']:.1f}"
                        f"   reward {b['value']:.3f} (n={b['n']}){entry}")
+        extras = []
+        if gen.get("verify_offered"):
+            extras.append("self-check + retry variant offered (Verification Optimizer)")
+        if gen.get("competent_model"):
+            comp = gen.get("model_competence") or {}
+            ranked = ", ".join(f"{m} {a:.2f}" for m, a in sorted(comp.items(), key=lambda kv: -kv[1]))
+            extras.append(f"model competence — best: {gen['competent_model']} ({ranked})")
+        for e in extras:
+            out.append(f"      └ {e}")
     elif gen is not None:
         out.append(_section("generation"))
         out.append(f"  {gen.get('note', 'legacy single_shot')}")

--- a/context_runtime/integrations/librechat.py
+++ b/context_runtime/integrations/librechat.py
@@ -395,8 +395,17 @@ class LibreChatTenant:
                        "rerank": chosen.rerank, "bucket": bucket, "learned": key is not None,
                        "query_type": (self.query_classifier(request)
                                       if self.query_classifier is not None else None)},
+            "generation": self._generation_block(bucket, chosen.method, plan.chosen.model_tier),
             "served": {"context": served[:4000], "citations": [h.chunk_id for h in hits]},
         }
+
+    def _generation_block(self, bucket: str, method: str, tier: str) -> dict:
+        """The generation-strategy decision for the panel — the answer-plane mirror of the retrieval
+        block. Reads learned values from the runtime's generation bandit when present."""
+        from ..reasoner import strategies as genstrat
+        opt = getattr(self.runtime, "optimizer", None)
+        return genstrat.explain_block(bucket, method=method, tier=tier,
+                                      bandit=getattr(opt, "bandit", None))
 
     def _compare_hit(self, method: str, h: Hit) -> dict:
         """One hit for the transparency panel, with calibrated P(relevant) when available —
@@ -503,6 +512,7 @@ class LibreChatTenant:
             "decision": {"chosen": {"key": chosen.key, "method": chosen.method,
                                     "final_k": chosen.final_k, "rerank": chosen.rerank},
                          "candidates": candidates},
+            "generation": self._generation_block(bucket, chosen.method, plan.chosen.model_tier),
             "retrieval": retrieval, "served": served, "reward": reward,
         }
 

--- a/context_runtime/optimizer/online.py
+++ b/context_runtime/optimizer/online.py
@@ -45,8 +45,13 @@ def plan_key(candidate: Candidate) -> str:
     rstep = next((s for s in candidate.steps if s.type == "reason"), None)
     strat = (rstep.params.get("strategy", "") if rstep else "")
     if strat and strat != "single_shot":
-        # a self-checked variant is a distinct arm (+v), so the bandit learns where verification pays off
-        seg = strat + ("+v" if rstep and rstep.params.get("verify") else "")
+        # +sc (self-consistency) and +v (self-check) are distinct arms, so the bandit learns per class
+        # where Best@k and where verification pay off.
+        seg = strat
+        if rstep and (rstep.params.get("self_consistency") or 0) > 1:
+            seg += "+sc"
+        if rstep and rstep.params.get("verify"):
+            seg += "+v"
         return f"{method}:{seg}:{candidate.model_tier}"
     return f"{method}:{candidate.model_tier}"
 

--- a/context_runtime/optimizer/online.py
+++ b/context_runtime/optimizer/online.py
@@ -37,8 +37,14 @@ class _Arm:
 
 
 def plan_key(candidate: Candidate) -> str:
-    """The bandit arm for a candidate: its retrieval method × model tier — the decision that matters."""
+    """The bandit arm for a candidate: retrieval method × generation strategy × model tier — the
+    decisions that matter. The generation strategy is folded in only when the layer selected one
+    (anything but the legacy ``single_shot``), so existing arms keep their exact keys and learned
+    values when CR_GENSTRATEGY is off."""
     method = next((s.params.get("method", "") for s in candidate.steps if s.type == "retrieve"), "")
+    strat = next((s.params.get("strategy", "") for s in candidate.steps if s.type == "reason"), "")
+    if strat and strat != "single_shot":
+        return f"{method}:{strat}:{candidate.model_tier}"
     return f"{method}:{candidate.model_tier}"
 
 

--- a/context_runtime/optimizer/online.py
+++ b/context_runtime/optimizer/online.py
@@ -42,9 +42,12 @@ def plan_key(candidate: Candidate) -> str:
     (anything but the legacy ``single_shot``), so existing arms keep their exact keys and learned
     values when CR_GENSTRATEGY is off."""
     method = next((s.params.get("method", "") for s in candidate.steps if s.type == "retrieve"), "")
-    strat = next((s.params.get("strategy", "") for s in candidate.steps if s.type == "reason"), "")
+    rstep = next((s for s in candidate.steps if s.type == "reason"), None)
+    strat = (rstep.params.get("strategy", "") if rstep else "")
     if strat and strat != "single_shot":
-        return f"{method}:{strat}:{candidate.model_tier}"
+        # a self-checked variant is a distinct arm (+v), so the bandit learns where verification pays off
+        seg = strat + ("+v" if rstep and rstep.params.get("verify") else "")
+        return f"{method}:{seg}:{candidate.model_tier}"
     return f"{method}:{candidate.model_tier}"
 
 

--- a/context_runtime/planner/candidates.py
+++ b/context_runtime/planner/candidates.py
@@ -42,6 +42,10 @@ class RuleCandidateGenerator:
         bucket_methods, strategy, want_verify = rules.BUCKET_DEFAULTS[intent.bucket]
         methods = self._methods_for_intent(intent, bucket_methods)
         tiers = rules.BUCKET_TIERS[intent.bucket]
+        # Effort-up vs model-up (B): also offer the ladder at the premium tier, so the bandit weighs
+        # "more effort, same model" against "bigger model". Restricted/sensitive stays local.
+        if genstrat.effort_vs_model() and "premium" not in tiers and intent.bucket != "sensitive":
+            tiers = tiers + ("premium",)
         c = goal.constraints
         # citations are checked by the verify step, so requiring them implies verify
         require_verify = want_verify or c.require_verification or c.require_citations
@@ -54,29 +58,36 @@ class RuleCandidateGenerator:
         # Verification Optimizer: correctness-sensitive classes ALSO get a self-checked variant of each
         # strategy (a distinct arm) so the bandit can learn whether the self-check earns its cost here.
         verify_opts = (False, True) if genstrat.offers_verify(intent.bucket) else (False,)
+        # Self-consistency arm (A): a +sc variant samples K reasoning traces → consensus. Off → 0.
+        sc_k = genstrat.self_consistency_k() if genstrat.offers_self_consistency(intent.bucket) else 0
 
         out: list[Candidate] = []
         for method in methods:
             for tier in tiers:
                 for gstrat in gen_strats:
+                    # sc only on thinking strategies — sampling a terse no-think answer buys nothing.
+                    sc_opts = (0, sc_k) if (sc_k >= 2 and genstrat.enabled() and genstrat.get(gstrat).thinking) else (0,)
                     for do_verify in verify_opts:
-                        steps: list[StepSpec] = [
-                            StepSpec("retrieve", {"method": method, "top_k": self.default_top_k}),
-                        ]
-                        if method in ("hybrid", "vector", "code"):
-                            steps.append(StepSpec("rerank", {"final_k": self.final_k}))
-                        steps.append(StepSpec("compress", {"target_tokens": self.target_tokens}))
-                        steps.append(StepSpec("route", {"tier": tier}))
-                        reason_params = {"strategy": gstrat, "capability": "synthesis"}
-                        if genstrat.enabled():
-                            gs = genstrat.get(gstrat)
-                            reason_params.update(thinking=gs.thinking, max_tokens=gs.max_tokens)
-                            if do_verify:
-                                reason_params["verify"] = True
-                        steps.append(StepSpec("reason", reason_params))
-                        if require_verify:
-                            steps.append(StepSpec("verify", {"method": "citation"}))
-                        out.append(Candidate(steps=tuple(steps), model_tier=tier))
+                        for sc in sc_opts:
+                            steps: list[StepSpec] = [
+                                StepSpec("retrieve", {"method": method, "top_k": self.default_top_k}),
+                            ]
+                            if method in ("hybrid", "vector", "code"):
+                                steps.append(StepSpec("rerank", {"final_k": self.final_k}))
+                            steps.append(StepSpec("compress", {"target_tokens": self.target_tokens}))
+                            steps.append(StepSpec("route", {"tier": tier}))
+                            reason_params = {"strategy": gstrat, "capability": "synthesis"}
+                            if genstrat.enabled():
+                                gs = genstrat.get(gstrat)
+                                reason_params.update(thinking=gs.thinking, max_tokens=gs.max_tokens)
+                                if do_verify:
+                                    reason_params["verify"] = True
+                                if sc >= 2:
+                                    reason_params["self_consistency"] = sc
+                            steps.append(StepSpec("reason", reason_params))
+                            if require_verify:
+                                steps.append(StepSpec("verify", {"method": "citation"}))
+                            out.append(Candidate(steps=tuple(steps), model_tier=tier))
         return out
 
     def prune(self, candidates: list[Candidate], goal: Goal) -> list[Candidate]:

--- a/context_runtime/planner/candidates.py
+++ b/context_runtime/planner/candidates.py
@@ -6,6 +6,7 @@ the survivors.
 """
 from __future__ import annotations
 
+from ..reasoner import strategies as genstrat
 from ..types import Candidate, Goal, Intent, PluginInfo, StepSpec
 from . import representations, rules
 
@@ -45,20 +46,30 @@ class RuleCandidateGenerator:
         # citations are checked by the verify step, so requiring them implies verify
         require_verify = want_verify or c.require_verification or c.require_citations
 
+        # Generation-strategy layer (CR_GENSTRATEGY): the `reason` step becomes a bandit arm too — one
+        # candidate per (method × tier × generation strategy), the strategies seeded per intent bucket.
+        # Off → the single legacy strategy from BUCKET_DEFAULTS, so plans are byte-identical to before.
+        gen_strats = genstrat.strategies_for(intent.bucket) if genstrat.enabled() else (strategy,)
+
         out: list[Candidate] = []
         for method in methods:
             for tier in tiers:
-                steps: list[StepSpec] = [
-                    StepSpec("retrieve", {"method": method, "top_k": self.default_top_k}),
-                ]
-                if method in ("hybrid", "vector", "code"):
-                    steps.append(StepSpec("rerank", {"final_k": self.final_k}))
-                steps.append(StepSpec("compress", {"target_tokens": self.target_tokens}))
-                steps.append(StepSpec("route", {"tier": tier}))
-                steps.append(StepSpec("reason", {"strategy": strategy, "capability": "synthesis"}))
-                if require_verify:
-                    steps.append(StepSpec("verify", {"method": "citation"}))
-                out.append(Candidate(steps=tuple(steps), model_tier=tier))
+                for gstrat in gen_strats:
+                    steps: list[StepSpec] = [
+                        StepSpec("retrieve", {"method": method, "top_k": self.default_top_k}),
+                    ]
+                    if method in ("hybrid", "vector", "code"):
+                        steps.append(StepSpec("rerank", {"final_k": self.final_k}))
+                    steps.append(StepSpec("compress", {"target_tokens": self.target_tokens}))
+                    steps.append(StepSpec("route", {"tier": tier}))
+                    reason_params = {"strategy": gstrat, "capability": "synthesis"}
+                    if genstrat.enabled():
+                        gs = genstrat.get(gstrat)
+                        reason_params.update(thinking=gs.thinking, max_tokens=gs.max_tokens)
+                    steps.append(StepSpec("reason", reason_params))
+                    if require_verify:
+                        steps.append(StepSpec("verify", {"method": "citation"}))
+                    out.append(Candidate(steps=tuple(steps), model_tier=tier))
         return out
 
     def prune(self, candidates: list[Candidate], goal: Goal) -> list[Candidate]:

--- a/context_runtime/planner/candidates.py
+++ b/context_runtime/planner/candidates.py
@@ -51,25 +51,32 @@ class RuleCandidateGenerator:
         # Off → the single legacy strategy from BUCKET_DEFAULTS, so plans are byte-identical to before.
         gen_strats = genstrat.strategies_for(intent.bucket) if genstrat.enabled() else (strategy,)
 
+        # Verification Optimizer: correctness-sensitive classes ALSO get a self-checked variant of each
+        # strategy (a distinct arm) so the bandit can learn whether the self-check earns its cost here.
+        verify_opts = (False, True) if genstrat.offers_verify(intent.bucket) else (False,)
+
         out: list[Candidate] = []
         for method in methods:
             for tier in tiers:
                 for gstrat in gen_strats:
-                    steps: list[StepSpec] = [
-                        StepSpec("retrieve", {"method": method, "top_k": self.default_top_k}),
-                    ]
-                    if method in ("hybrid", "vector", "code"):
-                        steps.append(StepSpec("rerank", {"final_k": self.final_k}))
-                    steps.append(StepSpec("compress", {"target_tokens": self.target_tokens}))
-                    steps.append(StepSpec("route", {"tier": tier}))
-                    reason_params = {"strategy": gstrat, "capability": "synthesis"}
-                    if genstrat.enabled():
-                        gs = genstrat.get(gstrat)
-                        reason_params.update(thinking=gs.thinking, max_tokens=gs.max_tokens)
-                    steps.append(StepSpec("reason", reason_params))
-                    if require_verify:
-                        steps.append(StepSpec("verify", {"method": "citation"}))
-                    out.append(Candidate(steps=tuple(steps), model_tier=tier))
+                    for do_verify in verify_opts:
+                        steps: list[StepSpec] = [
+                            StepSpec("retrieve", {"method": method, "top_k": self.default_top_k}),
+                        ]
+                        if method in ("hybrid", "vector", "code"):
+                            steps.append(StepSpec("rerank", {"final_k": self.final_k}))
+                        steps.append(StepSpec("compress", {"target_tokens": self.target_tokens}))
+                        steps.append(StepSpec("route", {"tier": tier}))
+                        reason_params = {"strategy": gstrat, "capability": "synthesis"}
+                        if genstrat.enabled():
+                            gs = genstrat.get(gstrat)
+                            reason_params.update(thinking=gs.thinking, max_tokens=gs.max_tokens)
+                            if do_verify:
+                                reason_params["verify"] = True
+                        steps.append(StepSpec("reason", reason_params))
+                        if require_verify:
+                            steps.append(StepSpec("verify", {"method": "citation"}))
+                        out.append(Candidate(steps=tuple(steps), model_tier=tier))
         return out
 
     def prune(self, candidates: list[Candidate], goal: Goal) -> list[Candidate]:

--- a/context_runtime/reasoner/strategies.py
+++ b/context_runtime/reasoner/strategies.py
@@ -1,14 +1,17 @@
-"""Generation-strategy registry — the answer-plane arms (SPEC §4.4, generation-strategy layer).
+"""Reasoning-strategy registry — the Reasoning Plane's arms (SPEC §4.4).
 
-Producing an answer from retrieved context is not one fixed prompt; it is a choice among
-*strategies*, each a (system prompt, thinking flag, token budget, cost prior) bundle. The planner
-treats the choice as another bandit arm keyed by intent — the same self-optimization it already runs
-for retrieval — so one intent classification drives two decisions (retrieval method + generation
-strategy). This module holds the strategy definitions and the per-intent warm-start priors; the
-bandit refines them from measured reward (Phase 2).
+Once retrieval quality passes a threshold, the dominant error shifts from *missing knowledge* to
+*imperfect reasoning over correctly retrieved knowledge* — retrieval optimization and reasoning
+optimization are distinct problems. So reasoning over the assembled context is not one fixed prompt;
+it is a choice among *strategies*, each a (system prompt, thinking flag, token budget, cost prior)
+bundle. The planner treats the choice as another bandit arm keyed by intent (mission class) — the same
+self-optimization it runs for retrieval — so one classification drives two decisions (retrieval method
++ reasoning strategy). What the runtime learns here are **execution policies**, not answers ("this
+class needs decomposition; that model succeeds on this class; self-verification pays off here").
 
-Opt-in: only wired when CR_GENSTRATEGY is set (see planner.candidates); otherwise the planner keeps
-emitting the legacy ``single_shot`` reason step and nothing here is used.
+This module holds the strategy definitions and the per-mission-class warm-start priors; the bandit
+refines them from measured reward (Phase 2). Opt-in: only wired when CR_GENSTRATEGY is set (see
+planner.candidates); otherwise the planner keeps the legacy ``single_shot`` reason step.
 """
 from __future__ import annotations
 
@@ -96,6 +99,15 @@ DATASET_BUCKET = {"popqa": "exact_lookup", "musique": "multi_hop",
 # the bench names the cheapest arm `direct`; CR calls it `terse`.
 _BENCH_ALIAS = {"direct": "terse"}
 
+# ── Verification Optimizer (Phase 4) ──
+# Mission classes where a SELF-CHECKED variant of each strategy (verify the answer, retry once if it
+# fails the check) is ALSO offered as a distinct arm. The bandit then learns, per class, whether the
+# self-check pays off net of its extra cost — verification becomes a learned decision, not always-on.
+# Seeded to correctness-sensitive / error-costly classes; refined online like everything else.
+VERIFY_BUCKETS = frozenset({"high_risk", "sensitive", "incident", "multi_hop", "temporal"})
+VERIFY_FAITHFULNESS_MIN = 0.5   # first attempt below this faithfulness → one retry
+VERIFY_COST_MULT = 2.0          # a verified arm's cost prior ≈ generate + check (+ maybe regenerate)
+
 
 def enabled() -> bool:
     """Generation-strategy layer is opt-in via CR_GENSTRATEGY (mirrors CR_DIVER / CR_NEMOTRON)."""
@@ -104,6 +116,11 @@ def enabled() -> bool:
 
 def strategies_for(bucket: str) -> tuple[str, ...]:
     return _ACTIVE_PRIORS.get(bucket, DEFAULT_STRATEGIES)
+
+
+def offers_verify(bucket: str) -> bool:
+    """Whether to also offer self-checked (verify+retry) variants for this mission class."""
+    return enabled() and bucket in VERIFY_BUCKETS
 
 
 def set_priors(priors: dict) -> None:
@@ -117,12 +134,17 @@ def set_priors(priors: dict) -> None:
 
 
 def load_priors(path: str) -> dict:
-    """Load a compact ``{bucket: [strategies]}`` priors file (written by benchmarks/build_priors.py)
-    and apply it. Returns the applied mapping."""
+    """Load + apply a priors file written by benchmarks/build_priors.py. Two shapes are accepted:
+    the compact ``{bucket: [strategies]}`` map, or the richer ``{"strategies": {...},
+    "model_competence": {...}}``. Returns the parsed object."""
     import json
-    priors = json.load(open(path))
-    set_priors(priors)
-    return priors
+    data = json.load(open(path))
+    if isinstance(data, dict) and ("strategies" in data or "model_competence" in data):
+        set_priors(data.get("strategies") or {})
+        set_model_competence(data.get("model_competence") or {})
+    else:
+        set_priors(data)
+    return data
 
 
 def priors_from_ablation(results_dir: str, *, dataset_bucket: dict | None = None,
@@ -158,6 +180,47 @@ def priors_from_ablation(results_dir: str, *, dataset_bucket: dict | None = None
     return priors
 
 
+# ── Model competence (Phase 5) — "bigger ≠ better", learned per mission class ──
+# The reasoning arm already includes the model tier (see optimizer.plan_key), so the bandit learns
+# model competence per class ONLINE. This is its warm start + its transparency: which model actually
+# succeeds on which mission class, measured at oracle context (generation isolated from retrieval).
+_MODEL_COMPETENCE: dict[str, dict[str, float]] = {}
+
+
+def model_competence_from_ablation(results_dir: str, *, dataset_bucket: dict | None = None,
+                                   cond: str = "oracle") -> dict:
+    """``{bucket: {model: mean_acc}}`` from the eval_cube2 cells — the measured 'DeepSeek here, Qwen
+    there' signal. A model that over-abstains on a class shows a low number here and is routed around."""
+    import glob
+    import json
+
+    dataset_bucket = dataset_bucket or DATASET_BUCKET
+    agg: dict[str, dict[str, list]] = {}
+    for f in glob.glob(os.path.join(results_dir, "*.json")):
+        try:
+            cell = json.load(open(f))
+        except Exception:  # noqa: BLE001
+            continue
+        bucket = dataset_bucket.get(cell.get("dataset"))
+        model = cell.get("model")
+        acc = cell.get(f"acc_{cond}")
+        if not bucket or not model or acc is None:
+            continue
+        agg.setdefault(bucket, {}).setdefault(model, []).append(float(acc))
+    return {b: {m: round(sum(v) / len(v), 4) for m, v in per.items()} for b, per in agg.items()}
+
+
+def set_model_competence(comp: dict) -> None:
+    _MODEL_COMPETENCE.clear()
+    _MODEL_COMPETENCE.update({b: dict(m) for b, m in (comp or {}).items()})
+
+
+def competent_model(bucket: str) -> str | None:
+    """The best-measured model for a mission class (None if unknown) — the warm-start model pick."""
+    comp = _MODEL_COMPETENCE.get(bucket)
+    return max(comp, key=comp.get) if comp else None
+
+
 def get(name: str) -> GenerationStrategy:
     return STRATEGIES.get(name) or STRATEGIES["single_shot"]
 
@@ -185,7 +248,10 @@ def explain_block(bucket: str, *, method: str = "", tier: str = "", bandit=None)
         cands.append({"strategy": name, "thinking": spec.thinking, "max_tokens": spec.max_tokens,
                       "cost_units": spec.cost_units, "entry_point": i == 0,
                       "bandit": {"n": int(n), "value": round(float(val), 4)}})
-    return {"enabled": True, "bucket": bucket, "ladder": list(ladder), "candidates": cands}
+    return {"enabled": True, "bucket": bucket, "ladder": list(ladder), "candidates": cands,
+            "verify_offered": bucket in VERIFY_BUCKETS,
+            "model_competence": _MODEL_COMPETENCE.get(bucket),
+            "competent_model": competent_model(bucket)}
 
 
 def extract_final(text: str) -> str:

--- a/context_runtime/reasoner/strategies.py
+++ b/context_runtime/reasoner/strategies.py
@@ -1,0 +1,112 @@
+"""Generation-strategy registry — the answer-plane arms (SPEC §4.4, generation-strategy layer).
+
+Producing an answer from retrieved context is not one fixed prompt; it is a choice among
+*strategies*, each a (system prompt, thinking flag, token budget, cost prior) bundle. The planner
+treats the choice as another bandit arm keyed by intent — the same self-optimization it already runs
+for retrieval — so one intent classification drives two decisions (retrieval method + generation
+strategy). This module holds the strategy definitions and the per-intent warm-start priors; the
+bandit refines them from measured reward (Phase 2).
+
+Opt-in: only wired when CR_GENSTRATEGY is set (see planner.candidates); otherwise the planner keeps
+emitting the legacy ``single_shot`` reason step and nothing here is used.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Recalibrated abstention — the cure for over-abstention: don't bail when the pieces are present.
+_ABSTAIN = ("If the pieces needed to answer are present in the context, reason across them and answer; "
+            "say the context is insufficient only if it truly lacks the answer — never invent facts.")
+
+
+@dataclass(frozen=True)
+class GenerationStrategy:
+    """One answer-plane arm. ``extractive`` = the model ends with an ``Answer:`` line to pull from a
+    reasoning trace; ``cost_units`` is a rough relative prior (calls × tokens) for the cost model and
+    the escalation ladder ordering."""
+    name: str
+    system: str
+    thinking: bool
+    max_tokens: int
+    extractive: bool = False
+    cost_units: float = 1.0
+
+
+# The legacy default keeps the citation prompt + 1024-token budget the SingleShotReasoner used, so
+# `single_shot` behaves identically whether routed through here or the original reasoner.
+_LEGACY_SYSTEM = ("Answer the question using ONLY the provided context. Cite sources inline like "
+                  "[1], [2]. If the context is insufficient, say so plainly — do not invent facts.")
+
+STRATEGIES: dict[str, GenerationStrategy] = {
+    "single_shot": GenerationStrategy("single_shot", _LEGACY_SYSTEM, thinking=False, max_tokens=1024, cost_units=1.0),
+    # terse — extractive lookup answer, cheapest arm.
+    "terse": GenerationStrategy(
+        "terse",
+        "Answer using ONLY the provided context, in as few words as possible. If the answer is not in "
+        "the context, say so — do not invent facts.",
+        thinking=False, max_tokens=96, cost_units=0.4),
+    # reason — think then a short final answer (single-hop reasoning / synthesis).
+    "reason": GenerationStrategy(
+        "reason",
+        "Answer the question using ONLY the provided context. Think step by step, then give a short "
+        "final answer on a line beginning 'Answer:'. " + _ABSTAIN,
+        thinking=True, max_tokens=768, extractive=True, cost_units=2.5),
+    # decompose — list intermediate facts, answer each, compose (multi-hop).
+    "decompose": GenerationStrategy(
+        "decompose",
+        "Answer the multi-hop question using ONLY the provided context. First list the intermediate "
+        "facts needed and answer each from the context, then compose the final answer on a line "
+        "beginning 'Answer:'. " + _ABSTAIN,
+        thinking=True, max_tokens=1024, extractive=True, cost_units=3.5),
+    # mapreduce — extract structured facts per source, then aggregate (counting / temporal aggregation).
+    "mapreduce": GenerationStrategy(
+        "mapreduce",
+        "You aggregate across sources. From the context, extract every relevant fact as a bullet "
+        "'- (when, who/what, value)', then compute the answer over those facts and give it on a line "
+        "beginning 'Answer:'. " + _ABSTAIN,
+        thinking=True, max_tokens=1024, extractive=True, cost_units=4.0),
+}
+
+# Warm-start priors: per intent bucket, the strategies to offer (cheapest-capable first). These are
+# the escalation-ladder entry points, seeded from the offline oracle ablation (eval_cube2 Phase 0);
+# the bandit refines the ordering online. The first entry is the default pick before any learning.
+BUCKET_STRATEGIES: dict[str, tuple[str, ...]] = {
+    "exact_lookup":   ("terse",),
+    "conceptual":     ("reason", "terse"),
+    "incident":       ("reason",),
+    "code_reasoning": ("reason",),
+    "synthesis":      ("reason",),
+    "high_risk":      ("reason",),
+    "sensitive":      ("reason",),
+    "multi_hop":      ("decompose", "reason"),
+    "temporal":       ("mapreduce", "reason"),
+    "unknown":        ("reason", "terse"),
+}
+
+DEFAULT_STRATEGIES = ("reason",)
+
+
+def enabled() -> bool:
+    """Generation-strategy layer is opt-in via CR_GENSTRATEGY (mirrors CR_DIVER / CR_NEMOTRON)."""
+    return os.getenv("CR_GENSTRATEGY", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def strategies_for(bucket: str) -> tuple[str, ...]:
+    return BUCKET_STRATEGIES.get(bucket, DEFAULT_STRATEGIES)
+
+
+def get(name: str) -> GenerationStrategy:
+    return STRATEGIES.get(name) or STRATEGIES["single_shot"]
+
+
+def extract_final(text: str) -> str:
+    """Pull the final answer from a reasoning response: strip <think> blocks, take the last
+    'Answer:' line if present, else the last non-empty line."""
+    import re
+    body = re.sub(r"<think>.*?</think>", "", text or "", flags=re.S).strip()
+    for line in reversed(body.splitlines()):
+        s = line.strip()
+        if s.lower().startswith("answer:"):
+            return s.split(":", 1)[1].strip()
+    return body.splitlines()[-1].strip() if body.strip() else body

--- a/context_runtime/reasoner/strategies.py
+++ b/context_runtime/reasoner/strategies.py
@@ -86,6 +86,16 @@ BUCKET_STRATEGIES: dict[str, tuple[str, ...]] = {
 
 DEFAULT_STRATEGIES = ("reason",)
 
+# The ACTIVE ladders. Defaults to the hand-seeded priors above; a deployment overrides them from the
+# benchmark via load_priors / CR_GENSTRATEGY_PRIORS so the warm start is measured, not guessed.
+_ACTIVE_PRIORS: dict[str, tuple[str, ...]] = dict(BUCKET_STRATEGIES)
+
+# eval_cube2 datasets → intent buckets (the ablation's regime → CR's classifier bucket).
+DATASET_BUCKET = {"popqa": "exact_lookup", "musique": "multi_hop",
+                  "longmemeval": "temporal", "tempo": "temporal", "nutrition": "conceptual"}
+# the bench names the cheapest arm `direct`; CR calls it `terse`.
+_BENCH_ALIAS = {"direct": "terse"}
+
 
 def enabled() -> bool:
     """Generation-strategy layer is opt-in via CR_GENSTRATEGY (mirrors CR_DIVER / CR_NEMOTRON)."""
@@ -93,7 +103,59 @@ def enabled() -> bool:
 
 
 def strategies_for(bucket: str) -> tuple[str, ...]:
-    return BUCKET_STRATEGIES.get(bucket, DEFAULT_STRATEGIES)
+    return _ACTIVE_PRIORS.get(bucket, DEFAULT_STRATEGIES)
+
+
+def set_priors(priors: dict) -> None:
+    """Override the active strategy ladders (from a measured ablation). Unknown strategies are dropped;
+    each ladder is re-ordered cheapest-capable first so index 0 stays the escalation entry point."""
+    for bucket, strats in (priors or {}).items():
+        clean = [_BENCH_ALIAS.get(s, s) for s in strats]
+        clean = [s for s in dict.fromkeys(clean) if s in STRATEGIES]
+        if clean:
+            _ACTIVE_PRIORS[bucket] = tuple(sorted(clean, key=lambda s: get(s).cost_units))
+
+
+def load_priors(path: str) -> dict:
+    """Load a compact ``{bucket: [strategies]}`` priors file (written by benchmarks/build_priors.py)
+    and apply it. Returns the applied mapping."""
+    import json
+    priors = json.load(open(path))
+    set_priors(priors)
+    return priors
+
+
+def priors_from_ablation(results_dir: str, *, dataset_bucket: dict | None = None,
+                         cond: str = "oracle", margin: float = 0.1) -> dict:
+    """Compute per-bucket strategy ladders from the eval_cube2 cell JSONs. For each bucket (via
+    ``dataset_bucket``), average the cells' ``acc_<cond>`` per strategy, keep every strategy within
+    ``margin`` of the bucket's best (so a cheap-but-adequate arm stays the entry point and better
+    costlier ones stay on the ladder for escalation), and order cheapest-first. ``cond=oracle``
+    isolates generation from retrieval — the right signal to seed a generation prior."""
+    import glob
+    import json
+
+    dataset_bucket = dataset_bucket or DATASET_BUCKET
+    agg: dict[str, dict[str, list]] = {}
+    for f in glob.glob(os.path.join(results_dir, "*.json")):
+        try:
+            cell = json.load(open(f))
+        except Exception:  # noqa: BLE001
+            continue
+        bucket = dataset_bucket.get(cell.get("dataset"))
+        strat = _BENCH_ALIAS.get(cell.get("strategy"), cell.get("strategy"))
+        acc = cell.get(f"acc_{cond}")
+        if not bucket or strat not in STRATEGIES or acc is None:
+            continue
+        agg.setdefault(bucket, {}).setdefault(strat, []).append(float(acc))
+
+    priors: dict[str, tuple[str, ...]] = {}
+    for bucket, per_strat in agg.items():
+        mean = {s: sum(v) / len(v) for s, v in per_strat.items()}
+        best = max(mean.values())
+        keep = [s for s, a in mean.items() if a >= best - margin] or [max(mean, key=mean.get)]
+        priors[bucket] = tuple(sorted(keep, key=lambda s: get(s).cost_units))
+    return priors
 
 
 def get(name: str) -> GenerationStrategy:
@@ -136,3 +198,13 @@ def extract_final(text: str) -> str:
         if s.lower().startswith("answer:"):
             return s.split(":", 1)[1].strip()
     return body.splitlines()[-1].strip() if body.strip() else body
+
+
+# Auto-load measured priors at import when CR_GENSTRATEGY_PRIORS points at a priors file — so a
+# deployment's warm start comes from its own ablation without editing this module.
+_PRIORS_FILE = os.getenv("CR_GENSTRATEGY_PRIORS", "").strip()
+if _PRIORS_FILE:
+    try:
+        load_priors(_PRIORS_FILE)
+    except Exception:  # noqa: BLE001 — a missing/bad priors file must never break import
+        pass

--- a/context_runtime/reasoner/strategies.py
+++ b/context_runtime/reasoner/strategies.py
@@ -100,6 +100,32 @@ def get(name: str) -> GenerationStrategy:
     return STRATEGIES.get(name) or STRATEGIES["single_shot"]
 
 
+def explain_block(bucket: str, *, method: str = "", tier: str = "", bandit=None) -> dict:
+    """The generation-plane 'show your work' for the transparency panel + EXPLAIN — the mirror of the
+    retrieval decision block. Lists the intent bucket's strategy ladder, each arm's config (thinking,
+    budget, cost prior), the entry point (the default first pick), and — when a generation bandit is
+    supplied — the learned value per strategy arm (arm key = ``method:strategy:tier``, matching
+    ``optimizer.online.plan_key``). Off → reports the legacy single_shot."""
+    if not enabled():
+        return {"enabled": False, "strategy": "single_shot",
+                "note": "generation-strategy layer off (set CR_GENSTRATEGY=1)"}
+    ladder = strategies_for(bucket)
+    cands = []
+    for i, name in enumerate(ladder):
+        spec = get(name)
+        arm = f"{method}:{name}:{tier}" if (method or tier) else name
+        n, val = 0, 0.0
+        if bandit is not None:
+            try:
+                n, val = bandit.value(bucket, arm)
+            except Exception:  # noqa: BLE001 — transparency must never break serving
+                pass
+        cands.append({"strategy": name, "thinking": spec.thinking, "max_tokens": spec.max_tokens,
+                      "cost_units": spec.cost_units, "entry_point": i == 0,
+                      "bandit": {"n": int(n), "value": round(float(val), 4)}})
+    return {"enabled": True, "bucket": bucket, "ladder": list(ladder), "candidates": cands}
+
+
 def extract_final(text: str) -> str:
     """Pull the final answer from a reasoning response: strip <think> blocks, take the last
     'Answer:' line if present, else the last non-empty line."""

--- a/context_runtime/reasoner/strategies.py
+++ b/context_runtime/reasoner/strategies.py
@@ -123,6 +123,59 @@ def offers_verify(bucket: str) -> bool:
     return enabled() and bucket in VERIFY_BUCKETS
 
 
+# ── Self-consistency arm (A) — Best@k / majority@k as an effort tier ──
+# The strongest inference-scaling lever (Best@k ≫ Pass@1): sample K reasoning traces and return the
+# consensus answer. A distinct arm (+sc) the bandit deploys per class where it pays. Opt-in
+# (CR_SELFCONSISTENCY) so the default candidate set (verify only) is unchanged.
+SC_BUCKETS = frozenset({"high_risk", "sensitive", "incident", "multi_hop", "temporal"})
+
+
+def self_consistency_enabled() -> bool:
+    return os.getenv("CR_SELFCONSISTENCY", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def self_consistency_k() -> int:
+    """Sample count K (CR_SC_K, default 5, min 2). Best@k rises with K."""
+    try:
+        k = int(os.getenv("CR_SC_K", "5"))
+        return k if k >= 2 else 5
+    except ValueError:
+        return 5
+
+
+def self_consistency_temp() -> float:
+    """Sampling temperature for the K samples (CR_SC_TEMP, default 0.7) — must be > 0 or the samples
+    don't diverge and self-consistency is vacuous."""
+    try:
+        t = float(os.getenv("CR_SC_TEMP", "0.7"))
+        return t if t > 0 else 0.7
+    except ValueError:
+        return 0.7
+
+
+def offers_self_consistency(bucket: str) -> bool:
+    """Whether to also offer a +sc variant for this class (thinking arms only)."""
+    return enabled() and self_consistency_enabled() and bucket in SC_BUCKETS
+
+
+# ── Self-refinement depth (C) — verify+retry as an N-iteration budget ──
+def refine_depth() -> int:
+    """Self-check→retry rounds for a verified arm (CR_REFINE_DEPTH, default 1 = the prior single retry).
+    Sequential self-refinement scales quality; the bandit still learns whether the extra rounds pay."""
+    try:
+        d = int(os.getenv("CR_REFINE_DEPTH", "1"))
+        return d if d >= 1 else 1
+    except ValueError:
+        return 1
+
+
+# ── Effort-up vs model-up (B) ──
+def effort_vs_model() -> bool:
+    """Offer a cheap-tier bucket's ladder at BOTH its tier and the strong tier, so the bandit weighs
+    'more effort, same model' against 'bigger model' (CR_EFFORT_VS_MODEL). Opt-in."""
+    return os.getenv("CR_EFFORT_VS_MODEL", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def set_priors(priors: dict) -> None:
     """Override the active strategy ladders (from a measured ablation). Unknown strategies are dropped;
     each ladder is re-ordered cheapest-capable first so index 0 stays the escalation entry point."""
@@ -250,8 +303,47 @@ def explain_block(bucket: str, *, method: str = "", tier: str = "", bandit=None)
                       "bandit": {"n": int(n), "value": round(float(val), 4)}})
     return {"enabled": True, "bucket": bucket, "ladder": list(ladder), "candidates": cands,
             "verify_offered": bucket in VERIFY_BUCKETS,
+            "sc_offered": offers_self_consistency(bucket), "sc_k": self_consistency_k(),
+            "effort_menu": _effort_menu(bucket, method=method, tier=tier, bandit=bandit),
+            "effort_note": ("cost_units vs learned value — pareto_optimal marks the non-dominated "
+                            "effort tier (no cheaper arm scores as high); effort is spent up the frontier."),
             "model_competence": _MODEL_COMPETENCE.get(bucket),
             "competent_model": competent_model(bucket)}
+
+
+def _effort_menu(bucket: str, *, method: str = "", tier: str = "", bandit=None) -> list[dict]:
+    """The full effort menu (D): each strategy × {base, +sc, +v, +sc+v} with its cost prior and learned
+    value, flagging the cost/quality Pareto frontier (an arm is pareto-optimal if no other arm has
+    ≤ cost AND ≥ value). Makes 'picked the cheapest arm that scores as high' legible in EXPLAIN."""
+    offer_v = enabled() and bucket in VERIFY_BUCKETS
+    offer_sc = offers_self_consistency(bucket)
+    k = self_consistency_k()
+    arms = []
+    for name in strategies_for(bucket):
+        spec = get(name)
+        variants = [("", spec.cost_units)]
+        if offer_sc and spec.thinking:
+            variants.append(("+sc", spec.cost_units * k))
+        if offer_v:
+            variants.append(("+v", spec.cost_units * VERIFY_COST_MULT))
+        if offer_sc and offer_v and spec.thinking:
+            variants.append(("+sc+v", spec.cost_units * k * VERIFY_COST_MULT))
+        for suffix, cost in variants:
+            arm_key = f"{method}:{name}{suffix}:{tier}" if (method or tier) else f"{name}{suffix}"
+            n, val = 0, 0.0
+            if bandit is not None:
+                try:
+                    n, val = bandit.value(bucket, arm_key)
+                except Exception:  # noqa: BLE001 — transparency must never break serving
+                    pass
+            arms.append({"arm": f"{name}{suffix}", "strategy": name, "variant": suffix,
+                         "cost_units": round(float(cost), 4), "value": round(float(val), 4), "n": int(n)})
+    for a in arms:
+        a["pareto_optimal"] = not any(
+            b is not a and b["cost_units"] <= a["cost_units"] and b["value"] >= a["value"]
+            and (b["cost_units"] < a["cost_units"] or b["value"] > a["value"])
+            for b in arms)
+    return arms
 
 
 def extract_final(text: str) -> str:

--- a/context_runtime/reasoner/strategy_reasoner.py
+++ b/context_runtime/reasoner/strategy_reasoner.py
@@ -1,0 +1,45 @@
+"""StrategyReasoner — a parametric Reasoner that executes a chosen generation strategy.
+
+Generalizes :class:`SingleShotReasoner`: instead of one fixed prompt/budget, it looks up the
+strategy (terse · reason · decompose · mapreduce · single_shot) and threads its system prompt,
+thinking flag, and token budget into the ModelRequest. For a reasoning strategy that ends with an
+``Answer:`` line, it extracts the final answer from the trace so downstream (verify, the panel) sees
+the answer, not the scratchpad. Same ReasonerPlugin seam as SingleShotReasoner, so the runtime's
+reason node dispatches to it by the plan's reason-step ``strategy`` param with nothing else changing.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from ..plugins.base import ModelPlugin
+from ..types import ModelRequest, ModelResult, PluginInfo, ReasonRequest
+from . import strategies
+
+
+class StrategyReasoner:
+    def __init__(self, model: ModelPlugin, strategy: str = "reason"):
+        self.model = model
+        self.strategy = strategies.get(strategy)
+
+    def reason(self, req: ReasonRequest) -> ModelResult:
+        s = self.strategy
+        ctx = req.context
+        question = ctx.plan.intent.normalized or ctx.plan.id
+        prompt = f"Context:\n{ctx.assembled_text}\n\nQuestion: {question}"
+        mreq = ModelRequest(
+            messages=({"role": "user", "content": prompt},),
+            capability=req.capability,
+            system=s.system,
+            max_tokens=s.max_tokens,
+            thinking=s.thinking,
+        )
+        res = self.model.complete(mreq)
+        if s.extractive:
+            res = replace(res, text=strategies.extract_final(res.text))
+        if not res.models_used:
+            res = replace(res, models_used=(res.model,))
+        return res
+
+    def info(self) -> PluginInfo:
+        return PluginInfo(name=f"strategy:{self.strategy.name}", kind="reasoner",
+                          capabilities=frozenset({"single_shot", self.strategy.name}))

--- a/context_runtime/reasoner/strategy_reasoner.py
+++ b/context_runtime/reasoner/strategy_reasoner.py
@@ -17,11 +17,12 @@ from . import strategies
 
 
 class StrategyReasoner:
-    def __init__(self, model: ModelPlugin, strategy: str = "reason"):
+    def __init__(self, model: ModelPlugin, strategy: str = "reason", *, verify: bool = False):
         self.model = model
         self.strategy = strategies.get(strategy)
+        self.verify = verify
 
-    def reason(self, req: ReasonRequest) -> ModelResult:
+    def _one(self, req: ReasonRequest) -> ModelResult:
         s = self.strategy
         ctx = req.context
         question = ctx.plan.intent.normalized or ctx.plan.id
@@ -40,6 +41,21 @@ class StrategyReasoner:
             res = replace(res, models_used=(res.model,))
         return res
 
+    def reason(self, req: ReasonRequest) -> ModelResult:
+        res = self._one(req)
+        # Verification Optimizer: self-check the answer's grounding; if it's weak, retry once and keep
+        # the better attempt. This is the "self-check · retry" the runtime learns to spend on per class.
+        if self.verify:
+            from .verify import faithfulness
+            ctx_text = req.context.assembled_text
+            f0 = faithfulness(res.text, ctx_text)
+            if f0 < strategies.VERIFY_FAITHFULNESS_MIN:
+                retry = self._one(req)
+                if faithfulness(retry.text, ctx_text) > f0:
+                    res = retry
+        return res
+
     def info(self) -> PluginInfo:
-        return PluginInfo(name=f"strategy:{self.strategy.name}", kind="reasoner",
-                          capabilities=frozenset({"single_shot", self.strategy.name}))
+        caps = {"single_shot", self.strategy.name} | ({"verify"} if self.verify else set())
+        return PluginInfo(name=f"strategy:{self.strategy.name}{'+v' if self.verify else ''}",
+                          kind="reasoner", capabilities=frozenset(caps))

--- a/context_runtime/reasoner/strategy_reasoner.py
+++ b/context_runtime/reasoner/strategy_reasoner.py
@@ -17,12 +17,15 @@ from . import strategies
 
 
 class StrategyReasoner:
-    def __init__(self, model: ModelPlugin, strategy: str = "reason", *, verify: bool = False):
+    def __init__(self, model: ModelPlugin, strategy: str = "reason", *, verify: bool = False,
+                 samples: int = 0, refine_depth: int | None = None):
         self.model = model
         self.strategy = strategies.get(strategy)
         self.verify = verify
+        self.samples = samples   # ≥2 → self-consistency (+sc): sample K, return the consensus
+        self.refine_depth = strategies.refine_depth() if refine_depth is None else refine_depth
 
-    def _one(self, req: ReasonRequest) -> ModelResult:
+    def _one(self, req: ReasonRequest, *, temperature: float | None = None) -> ModelResult:
         s = self.strategy
         ctx = req.context
         question = ctx.plan.intent.normalized or ctx.plan.id
@@ -33,6 +36,7 @@ class StrategyReasoner:
             system=s.system,
             max_tokens=s.max_tokens,
             thinking=s.thinking,
+            temperature=temperature,
         )
         res = self.model.complete(mreq)
         if s.extractive:
@@ -42,20 +46,47 @@ class StrategyReasoner:
         return res
 
     def reason(self, req: ReasonRequest) -> ModelResult:
-        res = self._one(req)
-        # Verification Optimizer: self-check the answer's grounding; if it's weak, retry once and keep
-        # the better attempt. This is the "self-check · retry" the runtime learns to spend on per class.
+        res = self._self_consistent(req) if self.samples >= 2 else self._one(req)
         if self.verify:
-            from .verify import faithfulness
-            ctx_text = req.context.assembled_text
-            f0 = faithfulness(res.text, ctx_text)
-            if f0 < strategies.VERIFY_FAITHFULNESS_MIN:
-                retry = self._one(req)
-                if faithfulness(retry.text, ctx_text) > f0:
-                    res = retry
+            res = self._refine(req, res)
         return res
 
+    def _refine(self, req: ReasonRequest, res: ModelResult) -> ModelResult:
+        """Self-refinement (C): up to ``refine_depth`` self-check→retry rounds, keeping the most-grounded
+        attempt. Depth 1 reproduces the prior single retry."""
+        from .verify import faithfulness
+        ctx_text = req.context.assembled_text
+        best, best_f = res, faithfulness(res.text, ctx_text)
+        rounds = 0
+        while best_f < strategies.VERIFY_FAITHFULNESS_MIN and rounds < max(1, self.refine_depth):
+            retry = self._one(req)
+            f = faithfulness(retry.text, ctx_text)
+            if f > best_f:
+                best, best_f = retry, f
+            rounds += 1
+        return best
+
+    def _self_consistent(self, req: ReasonRequest) -> ModelResult:
+        """Self-consistency (A): sample K traces at temperature > 0, return the consensus answer (largest
+        agreement cluster, faithfulness tiebreak), rolling up the K-sample cost so the arm's cost prior
+        reflects the extra compute — the bandit still learns whether Best@k pays for this class."""
+        from .verify import consensus_index
+        temp = strategies.self_consistency_temp()
+        results = [self._one(req, temperature=temp) for _ in range(self.samples)]
+        if not results:
+            return self._one(req)
+        chosen = results[consensus_index([r.text for r in results], req.context.assembled_text)]
+        return replace(chosen,
+                       prompt_tokens=sum(r.prompt_tokens for r in results),
+                       completion_tokens=sum(r.completion_tokens for r in results),
+                       est_cost_usd=sum(r.est_cost_usd for r in results))
+
     def info(self) -> PluginInfo:
-        caps = {"single_shot", self.strategy.name} | ({"verify"} if self.verify else set())
-        return PluginInfo(name=f"strategy:{self.strategy.name}{'+v' if self.verify else ''}",
+        caps = {"single_shot", self.strategy.name}
+        suffix = ""
+        if self.samples >= 2:
+            caps.add("self_consistency"); suffix += "+sc"
+        if self.verify:
+            caps.add("verify"); suffix += "+v"
+        return PluginInfo(name=f"strategy:{self.strategy.name}{suffix}",
                           kind="reasoner", capabilities=frozenset(caps))

--- a/context_runtime/reasoner/verify.py
+++ b/context_runtime/reasoner/verify.py
@@ -69,6 +69,25 @@ def self_consistency(samples: list[str]) -> float:
     return best / len(samples)
 
 
+def consensus_index(answers: list[str], context: str = "") -> int:
+    """The index of the answer that best represents the majority across K samples (self-consistency, A):
+    the answer in the largest cluster sharing ≥60% content overlap with the others, tie-broken by
+    faithfulness to the context. Abstentions are skipped; all-abstain → 0 (the verifier floors it)."""
+    if not answers:
+        return 0
+    toks = [_content_tokens(a) for a in answers]
+    best_idx, best_score = -1, -1.0
+    for i, a in enumerate(answers):
+        if is_abstention(a) or not toks[i]:
+            continue
+        cluster = 1 + sum(1 for j, b in enumerate(answers)
+                          if j != i and not is_abstention(b) and len(toks[i] & toks[j]) / len(toks[i]) >= 0.6)
+        score = cluster + 0.001 * faithfulness(a, context)   # cluster size dominates; faith breaks ties
+        if score > best_score:
+            best_idx, best_score = i, score
+    return best_idx if best_idx >= 0 else 0
+
+
 class GenerationVerifier:
     """Produce a measured reward for a generated answer. ``judge`` (optional) is a
     ``judge(answer, context, question) -> float in [0,1]`` — e.g. an LLM grader — used in place of the

--- a/context_runtime/reasoner/verify.py
+++ b/context_runtime/reasoner/verify.py
@@ -1,0 +1,128 @@
+"""Generation reward + escalation (Phase 2) — the measured signal that makes the answer plane
+self-optimizing.
+
+Retrieval reward is measurable online; generation reward normally needs gold. The cheapest form that
+answers the question here is a composite verifier:
+
+  * faithfulness — is the answer grounded in the retrieved context? (a cheap content-overlap proxy by
+    default; swap in an NLI/LLM judge via the ``judge`` hook for higher fidelity)
+  * abstention — an answer that gives up earns a low floor, so the escalation ladder is favored when a
+    costlier strategy might succeed (this is what cures over-abstention)
+  * self-consistency — optional agreement across K samples, for reasoning buckets
+
+The reward folds into the SAME outcome loop the retrieval bandit uses (``OutcomeEvent`` →
+``bandit.update``), keyed by the plan arm — which now includes the generation strategy. The escalation
+helpers pick the next rung when a cheap strategy underperforms; the optimizer runs it off the serving
+path (``select(..., shadow=True)``) and feeds its reward back, so latency stays bounded.
+"""
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+from . import strategies
+
+_WORD = re.compile(r"[a-z0-9]+")
+_ABSTAIN_MARKERS = ("not found", "insufficient", "cannot answer", "can't answer", "do not know",
+                    "don't know", "no answer", "not in the context", "unable to")
+_STOP = {"the", "a", "an", "of", "to", "in", "on", "for", "and", "or", "is", "are", "was", "were",
+         "it", "its", "as", "at", "by", "be", "this", "that", "with", "from"}
+
+# Reward below this → escalate to the next (costlier) strategy on the ladder.
+ESCALATE_BELOW = 0.5
+# An abstaining answer earns this floor: low enough to lose to any real answer, non-zero so a genuinely
+# unanswerable query (every strategy abstains) doesn't drive the arm's value negative.
+ABSTAIN_FLOOR = 0.1
+
+
+def _content_tokens(text: str) -> set[str]:
+    return {t for t in _WORD.findall((text or "").lower()) if t not in _STOP and len(t) > 1}
+
+
+def is_abstention(answer: str) -> bool:
+    a = (answer or "").strip().lower()
+    return not a or any(m in a for m in _ABSTAIN_MARKERS)
+
+
+def faithfulness(answer: str, context: str) -> float:
+    """Cheap grounding proxy in [0,1]: the fraction of the answer's content tokens that appear in the
+    context. High = grounded; low = the answer asserts things the context doesn't support
+    (hallucination or partial multi-hop). Empty answer → 0."""
+    ans = _content_tokens(answer)
+    if not ans:
+        return 0.0
+    ctx = _content_tokens(context)
+    return len(ans & ctx) / len(ans)
+
+
+def self_consistency(samples: list[str]) -> float:
+    """Agreement across K samples in [0,1]: the largest cluster sharing ≥60% content-token overlap,
+    normalized by K. 1.0 = all samples agree. Only meaningful for reasoning buckets."""
+    samples = [s for s in (samples or []) if s and not is_abstention(s)]
+    if len(samples) < 2:
+        return 1.0 if samples else 0.0
+    toks = [_content_tokens(s) for s in samples]
+    best = 1
+    for i, a in enumerate(toks):
+        agree = 1 + sum(1 for j, b in enumerate(toks) if j != i and a and len(a & b) / max(len(a), 1) >= 0.6)
+        best = max(best, agree)
+    return best / len(samples)
+
+
+class GenerationVerifier:
+    """Produce a measured reward for a generated answer. ``judge`` (optional) is a
+    ``judge(answer, context, question) -> float in [0,1]`` — e.g. an LLM grader — used in place of the
+    faithfulness proxy when supplied. Everything else stays cheap and offline."""
+
+    def __init__(self, judge: Callable[[str, str, str], float] | None = None,
+                 *, w_faith: float = 0.7, w_consistency: float = 0.3):
+        self.judge = judge
+        self.w_faith, self.w_consistency = w_faith, w_consistency
+
+    def reward(self, answer: str, context: str, question: str = "",
+               samples: list[str] | None = None) -> tuple[float, dict]:
+        abstained = is_abstention(answer)
+        if abstained:
+            return ABSTAIN_FLOOR, {"abstained": True, "faithfulness": 0.0, "consistency": None}
+        faith = self.judge(answer, context, question) if self.judge else faithfulness(answer, context)
+        cons = self_consistency(samples) if samples else None
+        reward = faith if cons is None else (self.w_faith * faith + self.w_consistency * cons)
+        return round(float(reward), 4), {"abstained": False, "faithfulness": round(faith, 4),
+                                         "consistency": None if cons is None else round(cons, 4)}
+
+
+# ─────────────────────────── escalation ladder ───────────────────────────
+def should_escalate(reward: float, threshold: float = ESCALATE_BELOW) -> bool:
+    return reward < threshold
+
+
+def next_strategy(bucket: str, current: str) -> str | None:
+    """The next (costlier) strategy on the bucket's ladder after ``current``; None at the top. The
+    ladder order is the warm-start priors (cheapest-capable first)."""
+    ladder = strategies.strategies_for(bucket)
+    if current in ladder:
+        i = ladder.index(current)
+        return ladder[i + 1] if i + 1 < len(ladder) else None
+    return ladder[0] if ladder else None
+
+
+# ─────────────────────────── feedback: reward → bandit ───────────────────────────
+def apply_feedback(optimizer, plan, answer: str, context: str, *, question: str = "", bucket: str = "",
+                   verifier: GenerationVerifier | None = None, samples: list[str] | None = None) -> dict:
+    """Score the served answer and fold the reward into the optimizer's learned policy (the same
+    ``learn_from_plan`` path retrieval uses), then report whether to escalate. Returns a dict with the
+    reward, the verifier signals, the OutcomeEvent, and the next strategy to shadow (or None). Pass
+    ``bucket`` (the selected Plan carries ``intent.bucket == 'unknown'`` until the runtime attaches it)
+    so escalation walks the right ladder."""
+    from ..learning.events import OutcomeEvent
+
+    verifier = verifier or GenerationVerifier()
+    reward, signals = verifier.reward(answer, context, question, samples)
+    # feed the same loop as retrieval; learn_from_plan reads plan.extra['bandit'] (arm includes strategy)
+    if hasattr(optimizer, "learn_from_plan"):
+        optimizer.learn_from_plan(plan, reward)
+    event = OutcomeEvent.from_plan(plan, reward, verified=not signals["abstained"])
+    strat = next((s.params.get("strategy") for s in plan.chosen.steps if s.type == "reason"), None)
+    bucket = bucket or (getattr(getattr(plan, "intent", None), "bucket", "") or "")
+    escalate_to = next_strategy(bucket, strat) if should_escalate(reward) else None
+    return {"reward": reward, "signals": signals, "event": event, "escalate_to": escalate_to}

--- a/context_runtime/runtime/runtime.py
+++ b/context_runtime/runtime/runtime.py
@@ -164,10 +164,17 @@ class ContextRuntime:
         tb.span("retrieve", "retrieve", {"hits": len(ctx.hits), "tokens": ctx.token_budget.get("compress", 0)},
                 t0, traces.now())
 
-        # reason (Reasoner → Router → Model)
+        # reason (Reasoner → Router → Model). Dispatch by the plan's generation strategy: `single_shot`
+        # keeps the legacy reasoner byte-for-byte; the generation-strategy arms route to StrategyReasoner.
         tier = ctx.plan.chosen.model_tier
         model = self.models.get(tier) or next(iter(self.models.values()))
-        reasoner = SingleShotReasoner(model)
+        _rstep = next((s for s in ctx.plan.chosen.steps if s.type == "reason"), None)
+        _strat = (_rstep.params.get("strategy") if _rstep else None) or "single_shot"
+        if _strat == "single_shot":
+            reasoner = SingleShotReasoner(model)
+        else:
+            from ..reasoner.strategy_reasoner import StrategyReasoner
+            reasoner = StrategyReasoner(model, _strat)
         t1 = traces.now()
         result = reasoner.reason(ReasonRequest(context=ctx, capability="synthesis",
                                                constraints=(goal.constraints if goal else Constraints())))

--- a/context_runtime/runtime/runtime.py
+++ b/context_runtime/runtime/runtime.py
@@ -174,7 +174,9 @@ class ContextRuntime:
             reasoner = SingleShotReasoner(model)
         else:
             from ..reasoner.strategy_reasoner import StrategyReasoner
-            reasoner = StrategyReasoner(model, _strat, verify=bool(_rstep and _rstep.params.get("verify")))
+            reasoner = StrategyReasoner(model, _strat,
+                                        verify=bool(_rstep and _rstep.params.get("verify")),
+                                        samples=int(_rstep.params.get("self_consistency") or 0) if _rstep else 0)
         t1 = traces.now()
         result = reasoner.reason(ReasonRequest(context=ctx, capability="synthesis",
                                                constraints=(goal.constraints if goal else Constraints())))

--- a/context_runtime/runtime/runtime.py
+++ b/context_runtime/runtime/runtime.py
@@ -174,7 +174,7 @@ class ContextRuntime:
             reasoner = SingleShotReasoner(model)
         else:
             from ..reasoner.strategy_reasoner import StrategyReasoner
-            reasoner = StrategyReasoner(model, _strat)
+            reasoner = StrategyReasoner(model, _strat, verify=bool(_rstep and _rstep.params.get("verify")))
         t1 = traces.now()
         result = reasoner.reason(ReasonRequest(context=ctx, capability="synthesis",
                                                constraints=(goal.constraints if goal else Constraints())))

--- a/context_runtime/types.py
+++ b/context_runtime/types.py
@@ -188,6 +188,7 @@ class ModelRequest:
     system: str | None = None
     tools: tuple[dict, ...] | None = None
     thinking: bool | None = None   # None = model default; True/False toggles a reasoning model's think mode
+    temperature: float | None = None   # None = adapter default; the +sc arm sets >0 so its K samples diverge
 
 
 @dataclass(frozen=True)

--- a/context_runtime/types.py
+++ b/context_runtime/types.py
@@ -187,6 +187,7 @@ class ModelRequest:
     max_tokens: int = 1024
     system: str | None = None
     tools: tuple[dict, ...] | None = None
+    thinking: bool | None = None   # None = model default; True/False toggles a reasoning model's think mode
 
 
 @dataclass(frozen=True)
@@ -201,7 +202,13 @@ class ModelResult:
     models_used: tuple[str, ...] = ()   # rolls up Reasoner sub-calls (SPEC §4.4)
 
 
-ReasoningStrategy = Literal["single_shot", "plan_worker_critic", "debate", "tool_loop"]
+# Reasoning/generation strategies. `single_shot` is the legacy default (one cite-based call). The
+# generation-strategy layer (CR_GENSTRATEGY) adds the answer-plane arms the bandit selects per intent:
+#   terse (extractive, no-think) · reason (think+CoT) · decompose (multi-hop) · mapreduce (aggregation).
+ReasoningStrategy = Literal[
+    "single_shot", "plan_worker_critic", "debate", "tool_loop",
+    "terse", "reason", "decompose", "mapreduce",
+]
 
 
 @dataclass(frozen=True)

--- a/deploy/financebench/README.md
+++ b/deploy/financebench/README.md
@@ -2,8 +2,8 @@
 
 The "crown jewel" demo: Context Runtime + the LibreChat **Libre Query Board** on data that
 is genuinely **hard to ingest and query** — real SEC 10-K/10-Q filings from
-[FinanceBench](https://github.com/patronus-ai/financebench) (Patronus AI), a recognized
-"RAG fails here" benchmark.
+[FinanceBench](https://github.com/patronus-ai/financebench) (Patronus AI, licensed
+CC-BY-4.0), a recognized "RAG fails here" benchmark.
 
 It shows the thesis directly: **no single retrieval method is enough**, and the runtime
 serves the best one while the Query Board makes every method's answer visible next to the

--- a/deploy/financebench/download.sh
+++ b/deploy/financebench/download.sh
@@ -2,7 +2,7 @@
 # Download the FinanceBench demo data: the open-source Q&A + a subset of SEC filing PDFs.
 # FinanceBench (Patronus AI, https://github.com/patronus-ai/financebench) — real 10-K/10-Q
 # filings + expert Q&A; a recognized "RAG is hard here" benchmark (dense tables, numerical,
-# multi-hop). Data lands in ../../.financebench/ (gitignored).
+# multi-hop). License: CC-BY-4.0 (Patronus AI). Data lands in ../../.financebench/ (gitignored).
 set -euo pipefail
 DEST="$(cd "$(dirname "$0")/../.." && pwd)/.financebench"
 RAW="https://raw.githubusercontent.com/patronus-ai/financebench/main"

--- a/docs/BENCHMARK-REPORT.md
+++ b/docs/BENCHMARK-REPORT.md
@@ -1,7 +1,69 @@
-# Final Benchmark Report
+# Context Runtime — Final Benchmark Report
 
-> **Consolidated into the canonical [`BENCHMARKS.md`](https://github.com/redevops-io/context-runtime/blob/main/BENCHMARKS.md).**
-The capability ladder + per-version drill-downs + methodology now live there as one document.
-The tenant/governance items this report covered (`hop_routing`, `trust_aware`, off-policy
-`online_learning`) are folded into its *Tenants & governance* and *v3* sections. Reproduce any
-example with `PYTHONPATH=. python examples/<name>.py`.
+_Full `examples/` suite run end-to-end on the v3 engine. Every number is produced by a runnable
+script (`PYTHONPATH=. python examples/<name>.py`) — no invented figures._
+
+**Run status: 30 / 30 benchmarks passed** (seeded, deterministic simulations; the consolidated
+headline is cross-checked in the independent Go re-implementation).
+
+**Judge change in this cycle:** the LLM-as-judge default moved from **OpenAI GPT-5.5 → Grok 4.5**
+(xAI, OpenAI-compatible, ~5× cheaper), now a *dedicated* judge endpoint kept separate from the chat
+model (`CR_JUDGE_BASE_URL` / `CR_JUDGE_MODEL` / `CR_JUDGE_API_KEY`, default `grok-4.5`). Note: the
+offline benchmarks below use a *seeded coverage judge* (no live LLM), so their numbers are unaffected
+by the judge model — the judge swap changes the **live** self-learning RAG's cost, not these results.
+
+---
+
+## 1. Headline — v1 → v2, measured in both runtimes (`consolidated_benchmark`)
+
+| Metric | Py v1 | Py v2 | Δ | Go v1 | Go v2 | Δ |
+| --- | --- | --- | --- | --- | --- | --- |
+| Learned-policy precision | 67.6% | 82.2% | ▲ +14.6 pts | 84.6% | 95.9% | ▲ +11.3 pts |
+| Abstention recall (unanswerable caught) | 0.0% | 100.0% | ▲ +100 pts | 0.0% | 100.0% | ▲ +100 pts |
+| False-abstain rate (answerable dropped) | 0.0% | 0.0% | — | 0.0% | 0.0% | — |
+| Expensive-stage depth (passages) | 8.00 | 3.00 | ▼ −62% | 8.00 | 3.00 | ▼ −63% |
+| Precision after the sizer | 37.5% | 100.0% | ▲ +62.5 pts | 37.5% | 100.0% | ▲ +62.5 pts |
+
+_40-seed average; precision headlined at β=0.9 (calibration-trust knob; shipped default 0.5). Go is an
+independent re-implementation on identical methodology — directional parity across languages._
+
+## 2. Calibration sweep (`dspark_calibration_bench`)
+
+Served true-precision, 40 seeds, coverage-biased judge:
+- v1 judge-only (β=0.0): **67.6%** → v2 judge + calibrated relevance: β0.5 **68.9%** (+1.3), β0.7 **74.3%** (+6.7), β0.9 **82.2%** (+14.6).
+- Abstention (P(rel)≥0.5 floor, v1 cannot abstain): sizer off → 8 passages @ 38% precision; sizer on → **3 passages @ 100%** (depth −62%, the pruned tail was the low-relevance one).
+
+## 3. Online adaptation under drift (Gen-4)
+
+- **`online_vs_static_bench`** — best plan drifts A→C at t=200. Post-drift served reward: static **0.20** · online-plain **0.33** · **online-discounted 0.67** (oracle 0.80). Discounting fades stale evidence so the planner tracks the shift.
+- **`online_learning`** — priors say hybrid=0.80/graph=0.55 (static always serves hybrid); production reward returns graph=0.9/hybrid=0.3 → after learning the planner serves **graph**, adapting past the stale estimate (surfaced without re-running it, via off-policy value).
+- **`learning_loop`** — async learning drained 8 events off the serving path → snapshot v1; replica reconciles and switches hybrid→graph with **zero learning on the hot path**.
+
+## 4. Retrieval methods & routing
+
+- **`hop_routing`** — intent-routed: conceptual → hybrid (acc 0.78, $0.06); **multi-hop → graph** (acc 0.88, $0.43), surfacing a bridge doc via the ATP→α-synuclein hop.
+- **`parallel_fusion`** — fan-out wall-clock **5.9× faster** (50.9 ms parallel vs 300.8 ms sequential), then rerank-before-model.
+- **`heterogeneous_shards`** — community/coverage routing cut cross-domain noise **23 → 0 docs** across 8 medical queries while keeping recall **8/8**.
+- **`multimodal_image_search`** — cross-modal text→image: each text query retrieves the right image as top hit (no OCR, no shared terms).
+- **`temporal_retrieval`** — bi-temporal as-of filtering (a record filed 2026-07-15 is correctly invisible to a 2026-06-15 as-of query).
+- **`rag_tuning`** — per-intent optimal config recovered (exact_lookup / incident / conceptual all match the latent best) after 40 observed retrievals.
+
+## 5. Trust & governance (Gen-5)
+
+- **`trust_aware`** — trust folded into plan selection (trust_weight 0.6 → the relied-upon local plan wins); abstention gate: expected accuracy 0.80 clears the 0.7 threshold → **SERVE** (else abstain).
+- **`capability_registry`, `explain`, `chat_memory`** — capability gating, EXPLAIN-ANALYZE traces, and conversational memory all green.
+
+## 6. Fleet / tenants (`fleet_tenants` + per-app demos)
+
+**17 tenants**, one pattern: each module = one goal, one metric, a learned *cheapest-sufficient source*
+policy — replacing hand-wired controllers with one data-driven Context Runtime tenant pattern. The
+per-app tenant demos all ran green: `agentic_billing, agentic_books, agentic_compliance,
+agentic_support, control_tower, market_radar, growth_engine, social_autopilot, outreach_engine,
+outreach_pipeline, incident_review, soc_triage, sidekick_learning, vibexgen_learning`.
+
+## Full run table
+
+All 30 scripts exited 0. Slowest: `consolidated_benchmark` (14s, runs the Go twin), `dspark_calibration_bench` (12s). One pre-existing example bug fixed this cycle: `fleet_tenants` was missing an `outreach` probe (added).
+
+_Reproduce any line: `PYTHONPATH=. python examples/<name>.py`. Headline card:
+`PYTHONPATH=. python examples/consolidated_benchmark.py --html out.html`._

--- a/docs/BENCHMARKS-v3-preliminary.md
+++ b/docs/BENCHMARKS-v3-preliminary.md
@@ -1,0 +1,19 @@
+# Benchmarks — v3 (preliminary)
+
+> **Preliminary.** This is a forward-looking axis distinct from — and not a replacement for — the
+> shipped v1→v2 calibration results in [`BENCHMARKS.md`](../BENCHMARKS.md). It is kept in its own
+> file until promoted. Reproduce with `PYTHONPATH=. python examples/consolidated_benchmark.py --v3-doc docs/BENCHMARKS-v3-preliminary.md`.
+
+## Online optimization under drift (Generation 4)
+
+The best plan drifts mid-run (a model upgrade, a corpus shift). A **static** v1/v2 planner is pinned
+to the now-stale plan; the **v3 online** planner re-explores, and recency-weighted (discounted)
+learning lets it track the shift. We report the post-drift average served-plan reward, seed-averaged.
+
+| Metric | v2 (static) | v3 (online) | Δ |
+| --- | --- | --- | --- |
+| Post-drift served-plan reward | 0.20 | 0.67 | ▲ +0.47 |
+| Post-drift reward, online w/o discounting | 0.20 | 0.34 | +0.14 |
+
+_Seeded drift simulation, 24-seed average; post-drift oracle = 0.80. Discounting is what converts online learning from a marginal gain into recovery of most of the
+oracle reward after the drift. This axis is orthogonal to (and preserves) the v2 calibration gains._

--- a/tests/test_generation_explain.py
+++ b/tests/test_generation_explain.py
@@ -1,0 +1,71 @@
+"""Generation-strategy layer (Phase 3) — transparency parity in compare + EXPLAIN.
+
+The generation decision is a first-class block alongside the retrieval decision: the strategy ladder
+for the intent, each arm's config + learned value, and the entry point. Rendered in the EXPLAIN text.
+"""
+from __future__ import annotations
+
+from context_runtime.explain import render_explain
+from context_runtime.reasoner import strategies as gs
+
+
+def test_explain_block_off_reports_legacy(monkeypatch):
+    monkeypatch.delenv("CR_GENSTRATEGY", raising=False)
+    blk = gs.explain_block("multi_hop")
+    assert blk == {"enabled": False, "strategy": "single_shot",
+                   "note": "generation-strategy layer off (set CR_GENSTRATEGY=1)"}
+
+
+def test_explain_block_on_shows_ladder_and_entry_point(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    blk = gs.explain_block("multi_hop", method="hybrid", tier="cheap")
+    assert blk["enabled"] and blk["ladder"] == ["decompose", "reason"]
+    entry = [c for c in blk["candidates"] if c["entry_point"]]
+    assert len(entry) == 1 and entry[0]["strategy"] == "decompose"    # cheapest-capable = entry point
+    d = next(c for c in blk["candidates"] if c["strategy"] == "decompose")
+    assert d["thinking"] is True and d["max_tokens"] == gs.get("decompose").max_tokens
+    assert all(c["bandit"] == {"n": 0, "value": 0.0} for c in blk["candidates"])   # unlearned yet
+
+
+def test_explain_block_surfaces_learned_values(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+
+    class _Bandit:
+        def value(self, ctx, arm):
+            return (5, 0.87) if (ctx == "multi_hop" and arm == "hybrid:decompose:cheap") else (0, 0.0)
+
+    blk = gs.explain_block("multi_hop", method="hybrid", tier="cheap", bandit=_Bandit())
+    d = next(c for c in blk["candidates"] if c["strategy"] == "decompose")
+    assert d["bandit"] == {"n": 5, "value": 0.87}
+
+
+def _min_exp(generation):
+    return {
+        "request": "how does auth relate to the billing outage", "intent_bucket": "multi_hop",
+        "query_type": None, "context_key": "multi_hop",
+        "decision": {"chosen": {"key": "hybrid:k5:rr", "method": "hybrid", "final_k": 5, "rerank": True},
+                     "candidates": [{"key": "hybrid:k5:rr", "method": "hybrid", "final_k": 5, "rerank": True,
+                                     "cost_units": 1.0, "bandit": {"n": 3, "value": 0.7}, "quality": None,
+                                     "chosen": True, "reason": "highest learned reward (0.7)"}]},
+        "generation": generation,
+        "retrieval": {"hybrid": []},
+        "served": {"method": "hybrid", "n": 0, "citations": [], "max_p_rel": None,
+                   "abstain": False, "abstain_reason": None},
+        "reward": {"policy": "native implicit signal", "calibrated": False, "reward_beta": 0.5,
+                   "quality_routing": False, "note": "reward = quality − λ·cost"},
+    }
+
+
+def test_render_explain_includes_the_generation_section(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    gen = gs.explain_block("multi_hop", method="hybrid", tier="cheap")
+    text = render_explain(_min_exp(gen))
+    assert "generation — strategy ladder for multi_hop" in text
+    assert "decompose" in text and "reason" in text
+    assert "entry point" in text
+
+
+def test_render_explain_notes_when_generation_layer_off(monkeypatch):
+    monkeypatch.delenv("CR_GENSTRATEGY", raising=False)
+    text = render_explain(_min_exp(gs.explain_block("multi_hop")))
+    assert "generation-strategy layer off" in text

--- a/tests/test_generation_explain.py
+++ b/tests/test_generation_explain.py
@@ -60,7 +60,7 @@ def test_render_explain_includes_the_generation_section(monkeypatch):
     monkeypatch.setenv("CR_GENSTRATEGY", "1")
     gen = gs.explain_block("multi_hop", method="hybrid", tier="cheap")
     text = render_explain(_min_exp(gen))
-    assert "generation — strategy ladder for multi_hop" in text
+    assert "reasoning — strategy ladder for multi_hop" in text
     assert "decompose" in text and "reason" in text
     assert "entry point" in text
 

--- a/tests/test_generation_priors.py
+++ b/tests/test_generation_priors.py
@@ -1,0 +1,69 @@
+"""Warm-start priors from the benchmark — the Phase 0 → Phase 1 bridge.
+
+`priors_from_ablation` turns eval_cube2 oracle cells into per-bucket strategy ladders (cheapest-capable
+first); `load_priors`/`set_priors` apply them so a deployment's warm start is measured, not guessed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from context_runtime.reasoner import strategies as gs
+
+
+@pytest.fixture(autouse=True)
+def _restore_priors():
+    """These tests mutate the module-global active ladders; snapshot + restore so they don't leak."""
+    snap = dict(gs._ACTIVE_PRIORS)
+    yield
+    gs._ACTIVE_PRIORS.clear()
+    gs._ACTIVE_PRIORS.update(snap)
+
+
+def _cell(tmp, dataset, strategy, oracle):
+    (tmp / f"{dataset}__hybrid__qwen__{strategy}.json").write_text(json.dumps(
+        {"dataset": dataset, "method": "hybrid", "model": "qwen", "strategy": strategy,
+         "n": 12, "acc_oracle": oracle}))
+
+
+def _ablation(tmp):
+    # musique (→multi_hop): decompose best, reason within margin, direct far below
+    _cell(tmp, "musique", "direct", 0.40); _cell(tmp, "musique", "reason", 0.85); _cell(tmp, "musique", "decompose", 0.90)
+    # longmemeval (→temporal): only mapreduce clears the bar
+    _cell(tmp, "longmemeval", "direct", 0.00); _cell(tmp, "longmemeval", "reason", 0.10); _cell(tmp, "longmemeval", "mapreduce", 0.60)
+    # popqa (→exact_lookup): terse and reason tie at ceiling
+    _cell(tmp, "popqa", "direct", 1.00); _cell(tmp, "popqa", "reason", 1.00)
+
+
+def test_priors_from_ablation_builds_cost_ordered_ladders(tmp_path):
+    _ablation(tmp_path)
+    priors = gs.priors_from_ablation(str(tmp_path), cond="oracle", margin=0.1)
+    # multi_hop: keep the two within-margin winners, cheapest (reason) as the entry point
+    assert priors["multi_hop"] == ("reason", "decompose")
+    # temporal: only mapreduce clears best-margin → it's the sole rung (must-mapreduce)
+    assert priors["temporal"] == ("mapreduce",)
+    # exact_lookup: both at ceiling → cheapest-first, and the bench 'direct' is aliased to 'terse'
+    assert priors["exact_lookup"] == ("terse", "reason")
+
+
+def test_load_priors_overrides_strategies_for(tmp_path):
+    p = tmp_path / "priors.json"
+    p.write_text(json.dumps({"multi_hop": ["decompose", "reason"], "temporal": ["mapreduce"]}))
+    applied = gs.load_priors(str(p))
+    assert applied["temporal"] == ["mapreduce"]
+    # set_priors re-orders cheapest-first regardless of input order → reason before decompose
+    assert gs.strategies_for("multi_hop") == ("reason", "decompose")
+    assert gs.strategies_for("temporal") == ("mapreduce",)
+
+
+def test_set_priors_drops_unknown_strategies_and_aliases_direct():
+    gs.set_priors({"exact_lookup": ["direct", "bogus", "reason"]})
+    assert gs.strategies_for("exact_lookup") == ("terse", "reason")   # direct→terse, bogus dropped
+
+
+def test_full_loop_ablation_to_active_ladder(tmp_path):
+    _ablation(tmp_path)
+    gs.set_priors(gs.priors_from_ablation(str(tmp_path)))
+    assert gs.strategies_for("temporal") == ("mapreduce",)
+    assert gs.strategies_for("multi_hop")[0] == "reason"   # measured entry point

--- a/tests/test_generation_reward.py
+++ b/tests/test_generation_reward.py
@@ -1,0 +1,91 @@
+"""Generation-strategy layer (Phase 2) — the measured-reward loop + escalation.
+
+Offline + deterministic: the cheap verifier scores an answer, the reward folds into the SAME bandit
+loop retrieval uses (keyed by the strategy-aware arm), and the escalation ladder picks the next rung
+when a strategy underperforms.
+"""
+from __future__ import annotations
+
+from context_runtime.optimizer.online import BanditOptimizer, plan_key
+from context_runtime.reasoner import verify
+from context_runtime.reasoner.verify import GenerationVerifier, apply_feedback, next_strategy, should_escalate
+from context_runtime.types import Candidate, Goal, Intent, Plan, PlanScore, StepSpec
+
+_CTX = "The auth service issues tokens. The billing outage was caused by token expiry."
+
+
+# ─────────────────────────── the verifier ───────────────────────────
+def test_reward_grounded_beats_hallucinated_beats_abstention():
+    v = GenerationVerifier()
+    grounded, _ = v.reward("token expiry", _CTX)
+    hallucinated, _ = v.reward("a disk controller firmware bug", _CTX)
+    abst, sig = v.reward("NOT FOUND", _CTX)
+    assert grounded > hallucinated
+    assert abst == verify.ABSTAIN_FLOOR and sig["abstained"] is True
+    assert grounded >= 0.9   # every content token is in the context
+
+
+def test_faithfulness_and_consistency_signals():
+    assert verify.faithfulness("token expiry", _CTX) == 1.0
+    assert verify.faithfulness("", _CTX) == 0.0
+    assert verify.self_consistency(["token expiry", "expiry of the token"]) == 1.0
+    assert verify.self_consistency(["token expiry", "disk failure"]) < 1.0
+
+
+def test_pluggable_judge_overrides_the_proxy():
+    v = GenerationVerifier(judge=lambda a, c, q: 0.42)
+    r, sig = v.reward("anything at all", _CTX)
+    assert r == 0.42 and sig["faithfulness"] == 0.42
+
+
+# ─────────────────────────── escalation ladder ───────────────────────────
+def test_ladder_walks_cheapest_to_costliest_then_stops():
+    # multi_hop ladder = ("decompose", "reason")
+    assert next_strategy("multi_hop", "decompose") == "reason"
+    assert next_strategy("multi_hop", "reason") is None          # top of the ladder
+    assert next_strategy("exact_lookup", "terse") is None        # single-rung ladder
+    assert should_escalate(0.2) and not should_escalate(0.8)
+
+
+# ─────────────────────────── reward → bandit (the self-optimization) ───────────────────────────
+def _cand(method, strategy, tier="cheap"):
+    return Candidate(steps=(StepSpec("retrieve", {"method": method}),
+                            StepSpec("reason", {"strategy": strategy})), model_tier=tier)
+
+
+class _Est:
+    def estimate(self, c, g): return PlanScore(total=0.5, feasible=True)
+    def statistics(self, bucket=None): raise NotImplementedError
+    def observe(self, p, t): raise NotImplementedError
+
+
+def test_apply_feedback_folds_generation_reward_into_the_strategy_arm():
+    opt = BanditOptimizer(_Est(), epsilon=0.0)
+    reason = _cand("hybrid", "reason")        # prior winner (0.9)
+    decompose = _cand("hybrid", "decompose")  # prior 0.4
+    scored = [(reason, PlanScore(total=0.9, feasible=True)),
+              (decompose, PlanScore(total=0.4, feasible=True))]
+    goal = Goal(text="how does auth relate to the billing outage")
+
+    assert opt.select(scored, goal, context="multi_hop").chosen is reason   # prior wins first
+    # decompose actually produces the grounded answer → high measured reward, fed via the verifier
+    plan_d = Plan(intent=Intent(bucket="multi_hop"), chosen=decompose, score=PlanScore(),
+                  extra={"bandit": {"context": "multi_hop", "arm": plan_key(decompose)}})
+    for _ in range(3):
+        out = apply_feedback(opt, plan_d, "token expiry", _CTX, bucket="multi_hop")
+        assert out["reward"] >= 0.9 and out["escalate_to"] is None
+    # the learned reward on the decompose arm now beats reason's prior
+    assert opt.select(scored, goal, context="multi_hop").chosen is decompose
+    n, mean = opt.bandit.value("multi_hop", plan_key(decompose))
+    assert n == 3 and mean >= 0.9
+
+
+def test_apply_feedback_flags_escalation_on_a_weak_answer():
+    opt = BanditOptimizer(_Est(), epsilon=0.0)
+    decompose = _cand("hybrid", "decompose")
+    plan = Plan(intent=Intent(bucket="multi_hop"), chosen=decompose, score=PlanScore(),
+                extra={"bandit": {"context": "multi_hop", "arm": plan_key(decompose)}})
+    out = apply_feedback(opt, plan, "NOT FOUND", _CTX, bucket="multi_hop")
+    assert out["reward"] == verify.ABSTAIN_FLOOR
+    assert out["escalate_to"] == "reason"          # the next (costlier) rung to shadow
+    assert out["event"].arm == plan_key(decompose) and out["event"].reward == verify.ABSTAIN_FLOOR

--- a/tests/test_generation_strategy.py
+++ b/tests/test_generation_strategy.py
@@ -1,0 +1,106 @@
+"""Generation-strategy layer (Phase 1) — the answer-plane arms.
+
+Offline (stub model): the layer is opt-in via CR_GENSTRATEGY. Off → plans are byte-identical to
+before (legacy single_shot). On → the `reason` step becomes a bandit arm: one candidate per intent
+strategy, carrying its thinking/budget, and the bandit arm key distinguishes strategies.
+"""
+from __future__ import annotations
+
+from context_runtime import ContextRuntime
+from context_runtime.optimizer.online import plan_key
+from context_runtime.reasoner import strategies as gs
+from context_runtime.types import Candidate, Constraints, Goal, StepSpec
+
+
+def _rt():
+    return ContextRuntime.default([
+        {"chunk_id": "a::0", "filename": "a.md", "text": "The auth service issues tokens.", "created_at": None},
+        {"chunk_id": "b::0", "filename": "b.md", "text": "The billing outage was caused by token expiry.", "created_at": None},
+    ])
+
+
+def _reason_strategy(cand) -> str:
+    return next((s.params.get("strategy") for s in cand.steps if s.type == "reason"), None)
+
+
+# ─────────────────────────── off: exact back-compat ───────────────────────────
+def test_disabled_keeps_legacy_single_shot(monkeypatch):
+    monkeypatch.delenv("CR_GENSTRATEGY", raising=False)
+    rt = _rt()
+    g = Goal(text="how does the auth service relate to the billing outage", constraints=Constraints())
+    cands = rt.candidates.generate(rt.intent.analyze(g), g)
+    assert cands and all(_reason_strategy(c) == "single_shot" for c in cands)
+    # the reason step carries no thinking/budget params when off (byte-identical plan)
+    rstep = next(s for s in cands[0].steps if s.type == "reason")
+    assert "thinking" not in rstep.params and "max_tokens" not in rstep.params
+
+
+# ─────────────────────────── on: strategy arms ───────────────────────────
+def test_enabled_generates_per_intent_strategy_arms(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    rt = _rt()
+    g = Goal(text="how does the auth service relate to the billing outage", constraints=Constraints())
+    intent = rt.intent.analyze(g)
+    assert intent.bucket == "multi_hop"
+    cands = rt.candidates.generate(intent, g)
+    strats = {_reason_strategy(c) for c in cands}
+    # multi_hop's warm-start strategies are offered as distinct candidates
+    assert strats == set(gs.strategies_for("multi_hop")) == {"decompose", "reason"}
+    # each reason step now carries its strategy's thinking flag + token budget
+    for c in cands:
+        rstep = next(s for s in c.steps if s.type == "reason")
+        spec = gs.get(rstep.params["strategy"])
+        assert rstep.params["thinking"] == spec.thinking
+        assert rstep.params["max_tokens"] == spec.max_tokens
+
+
+def test_lookup_bucket_offers_only_terse(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    rt = _rt()
+    g = Goal(text="ERR-500 status code", constraints=Constraints())
+    intent = rt.intent.analyze(g)
+    assert intent.bucket == "exact_lookup"
+    cands = rt.candidates.generate(intent, g)
+    assert {_reason_strategy(c) for c in cands} == {"terse"}   # cheapest arm only
+
+
+# ─────────────────────────── the bandit arm key ───────────────────────────
+def _cand(method, strategy, tier="cheap"):
+    steps = (StepSpec("retrieve", {"method": method}), StepSpec("reason", {"strategy": strategy}))
+    return Candidate(steps=steps, model_tier=tier)
+
+
+def test_plan_key_folds_in_strategy_but_not_single_shot():
+    # single_shot → legacy key (no strategy segment): existing learned values are preserved
+    assert plan_key(_cand("hybrid", "single_shot")) == "hybrid:cheap"
+    assert plan_key(_cand("hybrid", "")) == "hybrid:cheap"
+    # a real strategy becomes a distinct arm
+    assert plan_key(_cand("hybrid", "decompose")) == "hybrid:decompose:cheap"
+    assert plan_key(_cand("graph", "reason", "premium")) == "graph:reason:premium"
+    assert plan_key(_cand("hybrid", "decompose")) != plan_key(_cand("hybrid", "reason"))
+
+
+# ─────────────────────────── strategy registry + extraction ───────────────────────────
+def test_registry_covers_the_arms_and_orders_by_cost():
+    for name in ("terse", "reason", "decompose", "mapreduce", "single_shot"):
+        assert gs.get(name).name == name
+    # cheapest → most expensive prior (the escalation-ladder ordering)
+    assert gs.get("terse").cost_units < gs.get("reason").cost_units < gs.get("mapreduce").cost_units
+    assert gs.get("terse").thinking is False and gs.get("reason").thinking is True
+
+
+def test_extract_final_pulls_answer_and_strips_think():
+    out = "<think>the auth service relates via tokens; billing failed on expiry</think>\n" \
+          "Reasoning: token expiry cascaded.\nAnswer: token expiry"
+    assert gs.extract_final(out) == "token expiry"
+    assert gs.extract_final("just a direct answer") == "just a direct answer"
+
+
+# ─────────────────────────── end-to-end dispatch (stub model) ───────────────────────────
+def test_runtime_runs_a_strategy_plan(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    rt = _rt()
+    res = rt.run("how does the auth service relate to the billing outage")
+    # a generation strategy (not the legacy single_shot) was chosen and executed without error
+    assert _reason_strategy(res.plan.chosen) in {"decompose", "reason"}
+    assert isinstance(res.answer, str)

--- a/tests/test_generation_verify_model.py
+++ b/tests/test_generation_verify_model.py
@@ -1,0 +1,137 @@
+"""Reasoning Plane — Phase 4 (Verification Optimizer) + Phase 5 (model competence).
+
+Phase 4: correctness-sensitive mission classes also get a self-checked (verify + one retry) variant of
+each strategy as a DISTINCT arm, so the bandit learns where self-verification pays off.
+Phase 5: the reasoning arm already carries the model tier; here we warm-start + surface which model
+actually succeeds per mission class ("DeepSeek here, Qwen there"), measured at oracle.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from context_runtime import ContextRuntime
+from context_runtime.optimizer.online import plan_key
+from context_runtime.reasoner import strategies as gs
+from context_runtime.reasoner.strategy_reasoner import StrategyReasoner
+from context_runtime.types import Candidate, Goal, Constraints, ModelResult, ReasonRequest, StepSpec
+
+
+@pytest.fixture(autouse=True)
+def _restore():
+    ps, mc = dict(gs._ACTIVE_PRIORS), dict(gs._MODEL_COMPETENCE)
+    yield
+    gs._ACTIVE_PRIORS.clear(); gs._ACTIVE_PRIORS.update(ps)
+    gs._MODEL_COMPETENCE.clear(); gs._MODEL_COMPETENCE.update(mc)
+
+
+# ═══════════════════════════ Phase 4 — Verification Optimizer ═══════════════════════════
+def test_offers_verify_only_for_correctness_sensitive_classes(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    assert gs.offers_verify("multi_hop") and gs.offers_verify("high_risk")
+    assert not gs.offers_verify("exact_lookup") and not gs.offers_verify("conceptual")
+    monkeypatch.delenv("CR_GENSTRATEGY", raising=False)
+    assert not gs.offers_verify("multi_hop")   # gated by the flag
+
+
+def test_verify_variants_are_distinct_arms(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    rt = ContextRuntime.default([{"chunk_id": "a::0", "filename": "a.md", "text": "auth issues tokens", "created_at": None}])
+    g = Goal(text="how does auth relate to the billing outage", constraints=Constraints())
+    intent = rt.intent.analyze(g)
+    assert intent.bucket == "multi_hop"
+    cands = rt.candidates.generate(intent, g)
+    verified = [c for c in cands if any(s.type == "reason" and s.params.get("verify") for s in c.steps)]
+    plain = [c for c in cands if any(s.type == "reason" and not s.params.get("verify") for s in c.steps)]
+    assert verified and plain                      # both offered for a verify-bucket
+    # a verified candidate is a distinct bandit arm (+v)
+    assert plan_key(verified[0]).count("+v") == 1
+
+
+def test_plan_key_marks_the_verified_arm():
+    def cand(strategy, verify):
+        rp = {"strategy": strategy}
+        if verify:
+            rp["verify"] = True
+        return Candidate(steps=(StepSpec("retrieve", {"method": "hybrid"}), StepSpec("reason", rp)), model_tier="cheap")
+    assert plan_key(cand("decompose", False)) == "hybrid:decompose:cheap"
+    assert plan_key(cand("decompose", True)) == "hybrid:decompose+v:cheap"
+    assert plan_key(cand("decompose", True)) != plan_key(cand("decompose", False))
+
+
+class _SeqModel:
+    """Returns queued texts in order (last repeats) — to drive the self-check retry deterministically."""
+    def __init__(self, texts):
+        self.texts, self.calls = list(texts), 0
+
+    def complete(self, mreq):
+        t = self.texts[min(self.calls, len(self.texts) - 1)]
+        self.calls += 1
+        return ModelResult(text=t, model="stub", tier="local")
+
+    def capabilities(self, m):
+        from context_runtime.types import ModelCapabilities
+        return ModelCapabilities()
+
+
+def _req(context_text, question):
+    ctx = SimpleNamespace(assembled_text=context_text,
+                          plan=SimpleNamespace(id="p1", intent=SimpleNamespace(normalized=question)))
+    return ReasonRequest(context=ctx, capability="synthesis")
+
+
+def test_verify_retries_on_a_weak_first_answer():
+    # first answer is ungrounded (faithfulness 0), retry is grounded → the retry is kept
+    model = _SeqModel(["disk failure firmware bug", "token expiry"])
+    r = StrategyReasoner(model, "terse", verify=True)
+    res = r.reason(_req("token expiry caused the outage", "why outage"))
+    assert res.text == "token expiry" and model.calls == 2
+
+
+def test_verify_does_not_retry_a_grounded_answer():
+    model = _SeqModel(["token expiry", "SHOULD NOT BE USED"])
+    r = StrategyReasoner(model, "terse", verify=True)
+    res = r.reason(_req("token expiry caused the outage", "why outage"))
+    assert res.text == "token expiry" and model.calls == 1     # grounded → no retry
+
+
+# ═══════════════════════════ Phase 5 — model competence ═══════════════════════════
+def _cell(tmp, dataset, model, strategy, oracle):
+    (tmp / f"{dataset}__hybrid__{model}__{strategy}.json").write_text(json.dumps(
+        {"dataset": dataset, "method": "hybrid", "model": model, "strategy": strategy,
+         "n": 10, "acc_oracle": oracle}))
+
+
+def test_model_competence_from_ablation_ranks_models_per_class(tmp_path):
+    # musique (→multi_hop): Qwen succeeds at oracle, DeepSeek over-abstains (the report's finding #5)
+    _cell(tmp_path, "musique", "qwen", "decompose", 0.80)
+    _cell(tmp_path, "musique", "deepseek", "decompose", 0.00)
+    comp = gs.model_competence_from_ablation(str(tmp_path))
+    assert comp["multi_hop"] == {"qwen": 0.80, "deepseek": 0.00}
+    gs.set_model_competence(comp)
+    assert gs.competent_model("multi_hop") == "qwen"       # bigger != better, learned
+    assert gs.competent_model("temporal") is None          # unknown class
+
+
+def test_load_priors_richer_format_applies_strategies_and_competence(tmp_path):
+    p = tmp_path / "priors.json"
+    p.write_text(json.dumps({
+        "strategies": {"multi_hop": ["decompose", "reason"]},
+        "model_competence": {"multi_hop": {"qwen": 0.8, "deepseek": 0.0}},
+    }))
+    gs.load_priors(str(p))
+    assert gs.strategies_for("multi_hop") == ("reason", "decompose")   # cost-ordered
+    assert gs.competent_model("multi_hop") == "qwen"
+
+
+def test_explain_block_surfaces_verify_and_competence(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    gs.set_model_competence({"multi_hop": {"qwen": 0.8, "deepseek": 0.0}})
+    blk = gs.explain_block("multi_hop", method="hybrid", tier="cheap")
+    assert blk["verify_offered"] is True
+    assert blk["competent_model"] == "qwen"
+    assert blk["model_competence"] == {"qwen": 0.8, "deepseek": 0.0}
+    # a non-verify class shows no self-check offer
+    assert gs.explain_block("conceptual")["verify_offered"] is False

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -1,0 +1,101 @@
+"""Reasoning-effort control (A–D) — self-consistency arm, refine depth, effort menu/Pareto. Parity
+with context-runtime-go/reasoner/effort_test.go. Model-free (a fake ModelPlugin)."""
+from types import SimpleNamespace
+
+import pytest
+
+from context_runtime.reasoner import strategies as S
+from context_runtime.reasoner.verify import consensus_index
+from context_runtime.reasoner.strategy_reasoner import StrategyReasoner
+from context_runtime.optimizer.online import plan_key
+from context_runtime.types import Candidate, ModelResult, ReasonRequest, StepSpec
+
+
+# ── A: consensus + gating + plan_key ──────────────────────────────────────────────────────────
+def test_consensus_index_skips_abstention_and_picks_majority():
+    assert consensus_index(["NOT FOUND", "alpha beta", "alpha beta"], "alpha beta gamma") in (1, 2)
+    assert consensus_index(["x y z", "alpha beta", "alpha beta"], "alpha beta") in (1, 2)
+
+
+def test_offers_self_consistency_gated(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    monkeypatch.delenv("CR_SELFCONSISTENCY", raising=False)
+    assert not S.offers_self_consistency("multi_hop")
+    monkeypatch.setenv("CR_SELFCONSISTENCY", "1")
+    assert S.offers_self_consistency("multi_hop")
+    assert not S.offers_self_consistency("exact_lookup")
+
+
+def test_plan_key_encodes_sc_and_verify():
+    c = Candidate(steps=(StepSpec("retrieve", {"method": "hybrid"}),
+                         StepSpec("reason", {"strategy": "decompose", "self_consistency": 5, "verify": True})),
+                  model_tier="premium")
+    assert plan_key(c) == "hybrid:decompose+sc+v:premium"
+
+
+class FakeModel:
+    """Records temperature per call; returns scripted texts so consensus/refine are observable."""
+    def __init__(self, texts):
+        self.texts, self.calls, self.temps = texts, 0, []
+
+    def complete(self, req):
+        if req.temperature is not None:
+            self.temps.append(req.temperature)
+        txt = self.texts[min(self.calls, len(self.texts) - 1)]
+        self.calls += 1
+        return ModelResult(text=txt, model="fake", tier="cheap",
+                           prompt_tokens=10, completion_tokens=5, est_cost_usd=0.01)
+
+    def capabilities(self, model):  # pragma: no cover - interface shim
+        from context_runtime.types import ModelCapabilities
+        return ModelCapabilities()
+
+    def count_tokens(self, text, model=""):  # pragma: no cover
+        return len(text.split())
+
+    def info(self):
+        from context_runtime.types import PluginInfo
+        return PluginInfo(name="fake", kind="model")
+
+
+def _req(ctx_text, question):
+    ctx = SimpleNamespace(assembled_text=ctx_text,
+                          plan=SimpleNamespace(id="p1", intent=SimpleNamespace(normalized=question)))
+    return ReasonRequest(context=ctx, capability="synthesis")
+
+
+def test_self_consistency_samples_and_rolls_up_cost():
+    m = FakeModel(["Answer: alpha beta", "Answer: alpha beta", "Answer: zzz qqq"])
+    r = StrategyReasoner(m, "reason", samples=3)
+    res = r.reason(_req("alpha beta gamma", "q?"))
+    assert m.calls == 3 and len(m.temps) == 3 and m.temps[0] > 0     # K stochastic samples
+    assert res.text == "alpha beta"                                  # consensus of the agreeing pair
+    assert res.prompt_tokens == 30 and res.est_cost_usd == pytest.approx(0.03)  # K-sample cost
+    assert "+sc" in r.info().name
+
+
+# ── C: refine depth ───────────────────────────────────────────────────────────────────────────
+def test_refine_depth_retries_up_to_budget(monkeypatch):
+    monkeypatch.setenv("CR_REFINE_DEPTH", "3")
+    assert S.refine_depth() == 3
+    m = FakeModel(["zzz", "zzz", "zzz", "zzz"])           # never grounded → retries to the budget
+    StrategyReasoner(m, "reason", verify=True).reason(_req("alpha beta gamma", "q?"))
+    assert m.calls == 4                                    # 1 initial + 3 refine rounds
+
+
+def test_verify_stops_when_grounded(monkeypatch):
+    monkeypatch.setenv("CR_REFINE_DEPTH", "3")
+    m = FakeModel(["alpha beta gamma"])                   # grounded first attempt → no retry
+    StrategyReasoner(m, "reason", verify=True).reason(_req("alpha beta gamma delta", "q?"))
+    assert m.calls == 1
+
+
+# ── D: effort menu / Pareto ───────────────────────────────────────────────────────────────────
+def test_effort_menu_marks_pareto(monkeypatch):
+    monkeypatch.setenv("CR_GENSTRATEGY", "1")
+    monkeypatch.setenv("CR_SELFCONSISTENCY", "1")
+    blk = S.explain_block("multi_hop", method="hybrid", tier="premium")
+    menu = blk["effort_menu"]
+    assert menu and any("+sc" in a["arm"] for a in menu)
+    cheapest = min(menu, key=lambda a: a["cost_units"])
+    assert cheapest["pareto_optimal"] is True            # at zero learning the cheapest dominates


### PR DESCRIPTION
Consolidates the parallel **v4 reasoning line** into `main` so there is a single trunk, per the plan to collapse the diverged version branches into one final `main`.

## What this brings onto main
`v4` and `main` had diverged into parallel feature lines off a Jul-16 base:
- `main`: property-graph (cypher/gremlin) + cloud providers (AWS/Bedrock) + governance
- `v4`: the reasoning/generation plane (reasoning-effort control, Verification Optimizer, self-optimizing generation-strategy layer, model competence, Nemotron encoder, DIVER persistence)

This merges v4's reasoning plane onto main **additively** (21 files, mostly new).

## Conflict reconciliation (superset)
- **`reasoner/strategies.py`** — the two implementations that collided on this filename are unioned: main's concrete multi-shot reasoners (`PlanWorkerCritic`/`Debate`/`ToolLoop` + `reasoner_for`) **and** v4's generation-strategy registry / effort control (`GenerationStrategy`, `strategies_for`, self-consistency, refine, priors, `explain_block`). Zero name collisions; both APIs are imported by consolidated code.
- **`runtime/runtime.py`** — unified dispatch keyed by strategy name (disjoint namespaces): `single_shot`→SingleShot, `plan_worker_critic`/`debate`/`tool_loop`→`reasoner_for`, generation arms→`StrategyReasoner`.
- **Default strategy** — main's `BUCKET_DEFAULTS` stand (`multi_hop`/`synthesis`→`plan_worker_critic`); v4's back-compat test updated to assert the real contract ("genstrategy off → the legacy per-bucket default, no expansion").
- **`BENCHMARKS.md`** — kept main's pointer-style version.

## Also included
Runtime data-source **licensing** docs (`DATA_SOURCES.md`, financebench README/downloader): FinanceBench CC-BY-4.0, PubMedQA MIT; used only to benchmark the runtime, not redistributed.

## Validation
Full test suite green (45 reasoning/generation tests pass) except 3 that require the optional `duckdb` dep (environmental, unrelated).

## Follow-ups (not in this PR)
- Retire the stale `v1`–`v6` branches (v5/v6 both point at a Jul-15 commit, behind this) and tag consolidated `main` as `v7.0`.
- Resync the `benchmarks` harness branch onto the new `main` (kept as a separate harness branch).
- Obsoletes PRs #19 (main→v4) and #20 (benchmarks→v4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)