### PR TITLE
docs: fix stale test/tenant counts + de-historicize control-plane deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ replayable plan, and **learns from the outcome**. It does for AI context what qu
 planners did for SQL. See [POSITIONING.md](./POSITIONING.md) for the thesis.
 
 It optimizes any app with (a) a decision point about what context/config to use and
-(b) a measurable outcome. Eleven tenants are built and green (each number is the
-learned-vs-baseline reward its offline example in `examples/` prints):
+(b) a measurable outcome. The eleven tenants in the reward-table slice below are built and
+green (each number is the learned-vs-baseline reward its offline example in `examples/` prints):
 
 | Tenant | Context Runtime tunes | Result |
 |---|---|---|
@@ -67,7 +67,7 @@ while the core does the domain work:
 | lifecycle | Listmonk | guide | redevops-rag |
 
 Plus **outreach-engine** (Twenty CRM), and **growth-assistant** + **agentic-privacy** (both on ERPNext — leads / contacts, not books), and the **control plane**
-(`agentic_os`: deploy / observe / approve, `/m/<app>` proxy + a module catalog). Most have the offline
+(`context_runtime.control_plane`: deploy / observe / approve, `/m/<app>` proxy + a module catalog). Most have the offline
 reward examples shown above (`examples/<app>.py`); the rest are native realizations without a
 standalone tuner.
 
@@ -182,5 +182,5 @@ The decision layer is thin; the substrate is reused. See:
 ## Test
 
 ```bash
-pip install -e ".[dev]" && pytest      # 325 tests; test_conformance.py == SPEC §10
+pip install -e ".[dev]" && pytest      # the full conformance suite (test_conformance.py == SPEC §10)
 ```

--- a/context_runtime/control_plane/DEPLOY.md
+++ b/context_runtime/control_plane/DEPLOY.md
@@ -1,6 +1,6 @@
 # Deploying the Context Runtime control plane
 
-This replaces the retired `agentic-os` control-plane image. It serves the **same HTTP
+This is the Context Runtime control-plane image. It serves the **HTTP
 API** the demo + cloudflared depend on (`/`, `/health`, `/status`, `/modules`,
 `/m/<name>`, `/dispatch`, `/approvals`, `/agent/run`) on port **8080**, but the brain is
 Context Runtime's `ModuleTenant` fleet — so `/status` reflects real tenants, and every
@@ -17,11 +17,10 @@ uvicorn context_runtime.control_plane.app:app --host 0.0.0.0 --port 8080
 `CONTEXT_RUNTIME_API_KEY` gates the POST routes (falls back to `AGENTIC_OS_API_KEY` for
 compatibility). `CONTEXT_RUNTIME_HOME` holds the approvals/audit log.
 
-## Drop-in for `agentic-os-stack/integrated.compose.yml`
+## The `control-plane:` service in `agentic-os-stack/integrated.compose.yml`
 
-Replace the `control-plane:` service (which built from the now-gone
-`/projects/agentic-os-src`) with this — same port mapping, network, volume, and
-`depends_on`, only the build context + command change:
+The `control-plane:` service builds from Context Runtime as below — same port mapping,
+network, volume, and `depends_on`, with this build context + command:
 
 ```yaml
   control-plane:

--- a/docs/BENCHMARK-REPORT.md
+++ b/docs/BENCHMARK-REPORT.md
@@ -1,9 +1,9 @@
-# Context Runtime — Final Benchmark Report
+# Context Runtime — Benchmark Report
 
 _Full `examples/` suite run end-to-end on the v3 engine. Every number is produced by a runnable
 script (`PYTHONPATH=. python examples/<name>.py`) — no invented figures._
 
-**Run status: 30 / 30 benchmarks passed** (seeded, deterministic simulations; the consolidated
+**Run status (a benchmark run on the v3 engine): 30 / 30 benchmarks passed** (seeded, deterministic simulations; the consolidated
 headline is cross-checked in the independent Go re-implementation).
 
 **Judge change in this cycle:** the LLM-as-judge default moved from **OpenAI GPT-5.5 → Grok 4.5**
@@ -55,7 +55,7 @@ Served true-precision, 40 seeds, coverage-biased judge:
 
 ## 6. Fleet / tenants (`fleet_tenants` + per-app demos)
 
-**17 tenants**, one pattern: each module = one goal, one metric, a learned *cheapest-sufficient source*
+**17 benchmarked tenants**, one pattern: each module = one goal, one metric, a learned *cheapest-sufficient source*
 policy — replacing hand-wired controllers with one data-driven Context Runtime tenant pattern. The
 per-app tenant demos all ran green: `agentic_billing, agentic_books, agentic_compliance,
 agentic_support, control_tower, market_radar, growth_engine, social_autopilot, outreach_engine,
@@ -63,7 +63,7 @@ outreach_pipeline, incident_review, soc_triage, sidekick_learning, vibexgen_lear
 
 ## Full run table
 
-All 30 scripts exited 0. Slowest: `consolidated_benchmark` (14s, runs the Go twin), `dspark_calibration_bench` (12s). One pre-existing example bug fixed this cycle: `fleet_tenants` was missing an `outreach` probe (added).
+All 30 scripts exited 0. Slowest: `consolidated_benchmark` (14s, runs the Go twin), `dspark_calibration_bench` (12s).
 
 _Reproduce any line: `PYTHONPATH=. python examples/<name>.py`. Headline card:
 `PYTHONPATH=. python examples/consolidated_benchmark.py --html out.html`._


### PR DESCRIPTION
Surgical, pre-verified documentation fixes. No code or local design-vocabulary changes.

## README.md
- **Test count** — replaced the hardcoded `# 325 tests` (actual `def test_` count is 419) with a durable, non-numeric phrasing: `the full conformance suite (test_conformance.py == SPEC §10)`.
- **Tenant-count consistency** — L14 now states the eleven tenants are the reward-table/benchmark slice (the reward table has exactly 11 rows), so it no longer reads as contradicting the "15 native agent services" fleet figure (unchanged).
- **Control-plane label** — relabeled the control plane from the retired `agentic_os` to the package that actually exists, `context_runtime.control_plane`.

## context_runtime/control_plane/DEPLOY.md
- De-historicized the cutover language (dropped "retired / now-gone / replaces / Drop-in for") so the doc reads as the current control-plane deploy doc. All commands, ports, env vars, and compose config are unchanged.

## docs/BENCHMARK-REPORT.md
- Dropped the "Final" framing in the title and qualified the run status as a dated/versioned benchmark run (the doc carries no explicit run date, so it names the v3 engine per the existing text).
- `17 tenants` → `17 benchmarked tenants`, reconciling with the README.
- Removed the stale per-cycle changelog line about a `fleet_tenants` `outreach` probe fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)