### PR TITLE
feat: runtime-DAST plane — nmap/nuclei/ZAP scan of live deployments (deploy_scan MCP + CR tenant)

### DIFF
--- a/context_runtime/integrations/runtime_scan.py
+++ b/context_runtime/integrations/runtime_scan.py
@@ -1,0 +1,169 @@
+"""runtime-scan × Context Runtime — the deployment-DAST plane for edge-sentinel.
+
+The sibling of ``supply_chain`` (Trivy/Syft on images+lockfiles, i.e. *code & packages*).
+This plane scans the **running deployment** for exploitable exposure with real DAST tools —
+nmap (surface), nuclei (templated CVE/misconfig), ZAP (web/API DAST) — via the bundled
+``deploy_scan`` MCP server. The engine + scope live in ``runtime_scan_engine``; this module
+is the Context Runtime tenant: the decision is **which scan bundle to run** for a target, and
+the reward is *catching the real exposure at the cheapest scan cost*.
+
+Two invariants keep it safe to wire before you trust it:
+  1. Scope is a fail-closed allowlist (``SCAN_ALLOWLIST``) — see ``in_scope``.
+  2. Intrusive (active) scans are approval-gated; passive (recon/baseline) auto-approve.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..runtime.runtime import ContextRuntime
+from ..tools.base import ToolRegistry
+from ..types import Goal, Hit, Plan, Trace
+from .bandit import EpsilonGreedyBandit
+from .runtime_scan_engine import (  # re-exported for callers/tests
+    DeploymentScanner, Finding, OutOfScopeError, ScanReport, host_of, in_scope,
+    load_allowlist, scan_bucket,
+)
+
+__all__ = [
+    "DeploymentScanner", "Finding", "OutOfScopeError", "ScanReport", "ScanBundle",
+    "DEFAULT_BUNDLES", "COST_LAMBDA", "reward_scan", "RuntimeScanTenant", "ScanResult",
+    "mount_deploy_scan", "passive_only_approver", "in_scope", "host_of", "load_allowlist",
+    "scan_bucket",
+]
+
+
+# ──────────────────────────── the bandit arm ────────────────────────────
+
+
+@dataclass(frozen=True)
+class ScanBundle:
+    """A bandit arm: which scanners to run. Fewer/passive = cheaper; active = pricier + gated."""
+
+    tools: tuple[str, ...]
+
+    @property
+    def key(self) -> str:
+        return "+".join(self.tools)
+
+    @property
+    def has_active(self) -> bool:
+        return "zap_active" in self.tools
+
+
+DEFAULT_BUNDLES: tuple[ScanBundle, ...] = (
+    ScanBundle(("nmap",)),                           # recon only, cheapest
+    ScanBundle(("nuclei",)),                         # templated web, passive
+    ScanBundle(("zap_baseline",)),                   # passive web spider+scan
+    ScanBundle(("nmap", "nuclei")),                  # standard
+    ScanBundle(("nuclei", "zap_active")),            # deep web (INTRUSIVE, gated)
+    ScanBundle(("nmap", "nuclei", "zap_baseline")),  # thorough passive
+)
+# active scanning is disproportionately expensive (time + intrusiveness)
+_TOOL_COST = {"nmap": 1.0, "nuclei": 1.5, "zap_baseline": 2.0, "zap_active": 4.0}
+COST_LAMBDA = 0.15
+_MAX_COST = max(sum(_TOOL_COST[t] for t in b.tools) for b in DEFAULT_BUNDLES)
+
+
+def _bundle_cost(b: ScanBundle) -> float:
+    return sum(_TOOL_COST[t] for t in b.tools)
+
+
+def reward_scan(caught: bool, bundle: ScanBundle) -> float:
+    """Caught the real exposure at the cheapest sufficient bundle (the efficiency frontier)."""
+    if not caught:
+        return 0.0
+    return round(1.0 - COST_LAMBDA * (_bundle_cost(bundle) / _MAX_COST), 4)
+
+
+def _scan_bandit(epsilon: float = 0.15) -> EpsilonGreedyBandit:
+    return EpsilonGreedyBandit(DEFAULT_BUNDLES, epsilon=epsilon)
+
+
+def passive_only_approver(action: dict) -> bool:
+    """Default ApprovalPolicy approver: auto-approve passive scans, require a human for active
+    (intrusive) ones. Compose your own for the human step."""
+    args = action.get("args") or {}
+    prof = args.get("profile", "")
+    if prof:
+        from .runtime_scan_engine import ACTIVE_PROFILES
+        return prof not in ACTIVE_PROFILES
+    # bundle-shaped action (in-process path): allow unless it includes an active tool
+    tools = args.get("tools") or ()
+    return "zap_active" not in tools
+
+
+# ──────────────────────────── the tenant ────────────────────────────
+
+
+@dataclass
+class ScanResult:
+    target: str
+    bucket: str
+    bundle: ScanBundle
+    report: ScanReport
+    hits: tuple[Hit, ...]
+    max_severity: str
+    plan: Plan
+
+
+class RuntimeScanTenant:
+    """Context Runtime plans deployment DAST: classify the target, pick the cheapest scan bundle
+    that still catches the exposure, run it (scope- and approval-gated), and learn from whether
+    the exposure was really caught. Scans in-process via ``DeploymentScanner`` by default; pass a
+    registry with the deploy_scan MCP server mounted (``mount_deploy_scan``) to route through MCP."""
+
+    def __init__(self, runtime: ContextRuntime | None = None, registry: ToolRegistry | None = None,
+                 bandit: EpsilonGreedyBandit | None = None, scanner: DeploymentScanner | None = None):
+        self.runtime = runtime or ContextRuntime.default([])
+        self.bandit = bandit or _scan_bandit()
+        self.registry = registry
+        self.scanner = scanner or DeploymentScanner()
+        self._pending: dict[str, tuple[Plan, ScanBundle, str]] = {}
+
+    def scan(self, target: str) -> ScanResult:
+        if not in_scope(target, self.scanner.allowlist):
+            raise OutOfScopeError(f"{host_of(target)!r} not in SCAN_ALLOWLIST — refusing (fail-closed)")
+        bucket = scan_bucket(target)
+        plan = self.runtime.plan(Goal(text=f"scan {target}"))
+        bundle = self.bandit.select(bucket)
+        findings: list[Finding] = []
+        for tool in bundle.tools:
+            rep = self.scanner.run_tool(tool, target)
+            findings.extend(rep.findings)
+        report = ScanReport(True, target, sorted({f.tool for f in findings}),
+                            findings=findings, simulated=not self.scanner.live)
+        hits = tuple(f.as_hit(i) for i, f in enumerate(findings))
+        self._pending[self._key(target)] = (plan, bundle, bucket)
+        return ScanResult(target, bucket, bundle, report, hits, report.summary()["max_severity"], plan)
+
+    def record_outcome(self, target: str, exposure_confirmed: bool) -> float:
+        key = self._key(target)
+        if key not in self._pending:
+            return 0.0
+        plan, bundle, bucket = self._pending.pop(key)
+        reward = reward_scan(exposure_confirmed, bundle)
+        self.bandit.update(bucket, bundle, reward)
+        trace = Trace(plan_id=plan.id, goal_text=f"scan {target}",
+                      actual_tokens=int(_bundle_cost(bundle) * 200),
+                      verification_passed=exposure_confirmed)
+        self.runtime.estimator.observe(plan, trace)
+        return reward
+
+    def policy(self) -> dict[str, str]:
+        return self.bandit.policy()
+
+    @staticmethod
+    def _key(t: str) -> str:
+        import hashlib
+        return hashlib.sha256(t.encode()).hexdigest()[:16]
+
+
+def mount_deploy_scan(registry: ToolRegistry, *, python: str | None = None):
+    """Mount the bundled deploy_scan MCP server (stdio) into a registry, so the scan tools ride
+    the registry's ApprovalPolicy. Returns (client, tool_names)."""
+    import sys
+    from ..tools.mcp import MCPClient, mount_mcp
+    client = MCPClient.stdio([python or sys.executable, "-m",
+                              "context_runtime.tools.mcp_servers.deploy_scan"])
+    names = mount_mcp(registry, client, prefix="scan", default_side_effecting=True)
+    return client, names

--- a/context_runtime/integrations/runtime_scan_engine.py
+++ b/context_runtime/integrations/runtime_scan_engine.py
@@ -35,6 +35,19 @@ def host_of(target: str) -> str:
     return t.split("/")[0].split(":")[0].lower()
 
 
+def port_of(target: str) -> str | None:
+    """Explicit port from a URL / host:port, else None."""
+    t = (target or "").strip()
+    if "://" in t:
+        p = urllib.parse.urlparse(t).port
+        return str(p) if p else None
+    seg = t.split("/")[0]
+    if ":" in seg:
+        pt = seg.rsplit(":", 1)[1]
+        return pt if pt.isdigit() else None
+    return None
+
+
 def load_allowlist(env: str | None = None) -> list[str]:
     raw = env if env is not None else os.getenv("SCAN_ALLOWLIST", "")
     return [h.strip().lower() for h in raw.split(",") if h.strip()]
@@ -173,7 +186,19 @@ class DeploymentScanner:
         self._guard(target)
         if not (self.live and shutil.which("nmap")):
             return self._sim(target, "nmap")
-        rc, out, err = self._run(["nmap", "-Pn", "-T4", "--top-ports", "100", "-sV",
+        # Port selection: default the top 1000 (covers the common service range). SCAN_NMAP_PORTS
+        # overrides — a raw nmap flag ("--top-ports 3000", "-p-") or a port spec ("1-10000",
+        # "22,80,8230"). An explicit target port (host:PORT / URL) is always included, so services
+        # on high ports (e.g. an agent on :8230, outside the top-1000) aren't missed.
+        env_ports = os.getenv("SCAN_NMAP_PORTS", "").strip()
+        explicit = port_of(target)
+        if env_ports:
+            port_args = env_ports.split() if env_ports.startswith("-") else ["-p", env_ports]
+        elif explicit:
+            port_args = ["-p", f"1-1000,{explicit}"]
+        else:
+            port_args = ["--top-ports", "1000"]
+        rc, out, err = self._run(["nmap", "-Pn", "-T4", *port_args, "-sV",
                                   "--script", "ssl-enum-ciphers", host_of(target)])
         if rc != 0:
             return ScanReport(False, target, ["nmap"], note=f"nmap rc={rc}: {err[:140]}")

--- a/context_runtime/integrations/runtime_scan_engine.py
+++ b/context_runtime/integrations/runtime_scan_engine.py
@@ -1,0 +1,317 @@
+"""Runtime-DAST scanner engine — the light half of the deployment-scan plane.
+
+Kept free of ContextRuntime/bandit imports so the bundled ``deploy_scan`` MCP server can
+import it in a slim container (stdlib + ``Hit`` only), the way ``web_search`` stays keyless.
+
+Contents: scope allowlist (fail-closed), Finding/ScanReport, the DeploymentScanner (nmap +
+nuclei + ZAP as subprocesses, faithful simulated fallback), and output parsers.
+The CR tenant / bandit / reward live in ``runtime_scan.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import urllib.parse
+from dataclasses import dataclass, field
+
+from ..types import Hit
+
+_SEV_RANK = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+# ──────────────────────────── scope (fail-closed) ────────────────────────────
+
+
+def host_of(target: str) -> str:
+    """Host portion of a URL / host:port / bare host."""
+    t = (target or "").strip()
+    if "://" in t:
+        return (urllib.parse.urlparse(t).hostname or "").lower()
+    return t.split("/")[0].split(":")[0].lower()
+
+
+def load_allowlist(env: str | None = None) -> list[str]:
+    raw = env if env is not None else os.getenv("SCAN_ALLOWLIST", "")
+    return [h.strip().lower() for h in raw.split(",") if h.strip()]
+
+
+def in_scope(target: str, allowlist: list[str] | None = None) -> bool:
+    """True iff target's host is explicitly allowlisted. FAIL-CLOSED: empty allowlist ⇒ False.
+    Entries are exact hosts/IPs or ``*.domain`` wildcards."""
+    host = host_of(target)
+    if not host:
+        return False
+    al = allowlist if allowlist is not None else load_allowlist()
+    if not al:
+        return False
+    for entry in al:
+        if entry.startswith("*."):
+            base = entry[2:]
+            if host == base or host.endswith("." + base):
+                return True
+        elif host == entry:
+            return True
+    return False
+
+
+class OutOfScopeError(RuntimeError):
+    """Raised when a scan is requested against a host not in SCAN_ALLOWLIST."""
+
+
+# ──────────────────────────── findings ────────────────────────────
+
+
+@dataclass
+class Finding:
+    severity: str            # info | low | medium | high | critical
+    name: str
+    target: str
+    tool: str                # nmap | nuclei | zap
+    evidence: str = ""
+    ref: str = ""            # CVE / template-id / plugin-id
+
+    def as_hit(self, idx: int) -> Hit:
+        return Hit(chunk_id=f"{self.tool}::{idx}", filename=self.tool, source=self.tool,
+                   text=f"[{self.severity.upper()}] {self.name} @ {self.target}"
+                        + (f" ({self.ref})" if self.ref else ""),
+                   score=float(_SEV_RANK.get(self.severity, 0)) / 4.0)
+
+    def as_dict(self) -> dict:
+        return {"severity": self.severity, "name": self.name, "target": self.target,
+                "tool": self.tool, "evidence": self.evidence, "ref": self.ref}
+
+
+@dataclass
+class ScanReport:
+    ok: bool
+    target: str
+    tools_run: list[str] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+    note: str = ""
+    simulated: bool = False
+
+    def summary(self) -> dict:
+        counts: dict[str, int] = {}
+        for f in self.findings:
+            counts[f.severity] = counts.get(f.severity, 0) + 1
+        return {"target": self.target, "tools": self.tools_run, "total": len(self.findings),
+                "by_severity": counts, "simulated": self.simulated, "note": self.note,
+                "max_severity": max((f.severity for f in self.findings),
+                                    key=lambda s: _SEV_RANK.get(s, 0), default="none")}
+
+
+# ──────────────────────────── target classification + sim truth ────────────────────────────
+
+
+def scan_bucket(target: str) -> str:
+    """Target class → decisive exposure kind. Bare host/IP → TLS/network; a URL with a
+    path/params → web; login/search/api paths lean injection-y."""
+    t = (target or "").lower()
+    if re.search(r"\?|=|/(login|search|api|admin|user)\b", t):
+        return "injection"
+    if t.startswith("http") or "/" in t.split("://")[-1]:
+        return "web_cve"
+    return "tls"
+
+
+# Latent decisive tool per target class — the hidden exposure a bundle must include the right
+# tool to catch. Offline-simulation only (mirrors soc_triage's one-decisive-source design).
+_SIM_LATENT = {
+    "tls":       ("nmap",       ("high", "TLS 1.0/1.1 enabled + weak ciphers", "ssl-enum-ciphers")),
+    "web_cve":   ("nuclei",     ("critical", "Exposed .git/config or known CVE", "CVE-2021-41773")),
+    "injection": ("zap_active", ("high", "Reflected XSS in query parameter", "40012")),
+}
+
+
+class DeploymentScanner:
+    """Runs DAST tools as subprocesses (real when installed + SCAN_LIVE=1); otherwise returns a
+    faithful simulated report so the tenant runs offline. Every entrypoint enforces ``in_scope``
+    first — no scanner process is spawned for an off-scope host."""
+
+    TOOLS = ("nmap", "nuclei", "zap")
+
+    def __init__(self, timeout: float = 120.0, live: bool | None = None,
+                 allowlist: list[str] | None = None):
+        self.timeout = timeout
+        self.live = (os.getenv("SCAN_LIVE", "0") == "1") if live is None else live
+        self.allowlist = allowlist
+
+    def available(self) -> dict:
+        return {t: bool(shutil.which(t)) for t in self.TOOLS}
+
+    def _guard(self, target: str) -> None:
+        if not in_scope(target, self.allowlist):
+            raise OutOfScopeError(
+                f"{host_of(target)!r} is not in SCAN_ALLOWLIST — refusing to scan (fail-closed)")
+
+    def _run(self, cmd: list[str], timeout: float | None = None) -> tuple[int, str, str]:
+        t = timeout or self.timeout
+        try:
+            p = subprocess.run(cmd, text=True, capture_output=True, timeout=t)
+            return p.returncode, p.stdout, p.stderr
+        except FileNotFoundError:
+            return 127, "", f"{cmd[0]} not found"
+        except subprocess.TimeoutExpired:
+            return 124, "", f"{cmd[0]} timed out after {t}s"
+
+    def _docker_image(self) -> str | None:
+        """Return the ZAP container image if docker + the image are available, else None."""
+        if not shutil.which("docker"):
+            return None
+        image = os.getenv("SCAN_ZAP_IMAGE", "zaproxy/zap-stable")
+        rc, _, _ = self._run(["docker", "image", "inspect", image], timeout=20)
+        return image if rc == 0 else None
+
+    # ---- individual tools ---------------------------------------------------
+    def nmap_scan(self, target: str) -> ScanReport:
+        self._guard(target)
+        if not (self.live and shutil.which("nmap")):
+            return self._sim(target, "nmap")
+        rc, out, err = self._run(["nmap", "-Pn", "-T4", "--top-ports", "100", "-sV",
+                                  "--script", "ssl-enum-ciphers", host_of(target)])
+        if rc != 0:
+            return ScanReport(False, target, ["nmap"], note=f"nmap rc={rc}: {err[:140]}")
+        return ScanReport(True, target, ["nmap"], findings=_parse_nmap(out, target))
+
+    def nuclei_scan(self, target: str, severity: str = "low,medium,high,critical") -> ScanReport:
+        self._guard(target)
+        if not (self.live and shutil.which("nuclei")):
+            return self._sim(target, "nuclei")
+        rc, out, err = self._run(["nuclei", "-u", _as_url(target), "-severity", severity,
+                                  "-jsonl", "-silent", "-duc"])
+        if rc != 0:
+            return ScanReport(False, target, ["nuclei"], note=f"nuclei rc={rc}: {err[:140]}")
+        return ScanReport(True, target, ["nuclei"], findings=_parse_nuclei(out, target))
+
+    def zap_baseline(self, target: str) -> ScanReport:
+        return self._zap(target, active=False)
+
+    def zap_active(self, target: str) -> ScanReport:
+        return self._zap(target, active=True)
+
+    def _zap(self, target: str, *, active: bool) -> ScanReport:
+        self._guard(target)
+        tool = "zap_active" if active else "zap_baseline"
+        script = "zap-full-scan.py" if active else "zap-baseline.py"
+        kind = "active" if active else "baseline"
+        url = _as_url(target)
+        zap_timeout = max(self.timeout, float(os.getenv("SCAN_ZAP_TIMEOUT", "600")))
+        if not self.live:
+            return self._sim(target, tool)
+        # 1) native ZAP scripts on PATH
+        if shutil.which(script):
+            import tempfile
+            report = tempfile.NamedTemporaryFile("r", suffix=".json", delete=False).name
+            rc, _, _ = self._run([script, "-t", url, "-J", report, "-I"], timeout=zap_timeout)
+            return ScanReport(True, target, ["zap"], findings=_parse_zap(_read(report), target),
+                              note=f"{kind} native (rc={rc})")
+        # 2) containerized ZAP (zaproxy/zap-stable) — report lands in the mounted /zap/wrk
+        image = self._docker_image()
+        if image:
+            import tempfile
+            workdir = tempfile.mkdtemp(prefix="zap_")
+            os.chmod(workdir, 0o777)   # ZAP container's 'zap' user must be able to write the report
+            # --network host so the container can reach host-loopback / LAN deployments
+            # (a container's 127.0.0.1 is its own, not the host's). Works for public URLs too.
+            net = os.getenv("SCAN_ZAP_NETWORK", "host")
+            rc, _, err = self._run(
+                ["docker", "run", "--rm", "--network", net, "-v", f"{workdir}:/zap/wrk/:rw", image,
+                 script, "-t", url, "-J", "report.json", "-I"], timeout=zap_timeout)
+            raw = _read(os.path.join(workdir, "report.json"))
+            note = f"{kind} docker (rc={rc})" + ("" if raw else f" — no report: {err[:100]}")
+            return ScanReport(bool(raw) or rc == 0, target, ["zap"],
+                              findings=_parse_zap(raw, target), note=note)
+        # 3) neither available → simulate
+        return self._sim(target, tool)
+
+    # ---- simulation ---------------------------------------------------------
+    def _sim(self, target: str, tool: str) -> ScanReport:
+        """Deterministic simulated findings. A latent exposure keyed to the target class is only
+        surfaced by its decisive tool — so a bundle missing that tool misses it."""
+        cls = scan_bucket(target)
+        findings: list[Finding] = []
+        latent = _SIM_LATENT.get(cls)
+        if latent and latent[0] == tool:
+            sev, name, ref = latent[1]
+            findings.append(Finding(sev, name, target, tool.split("_")[0], evidence="simulated", ref=ref))
+        findings.append(Finding("info", f"{tool} baseline complete", target, tool.split("_")[0],
+                                evidence="simulated"))
+        return ScanReport(True, target, [tool.split("_")[0]], findings=findings, simulated=True)
+
+    def run_tool(self, tool: str, target: str) -> ScanReport:
+        fn = {"nmap": self.nmap_scan, "nuclei": self.nuclei_scan,
+              "zap_baseline": self.zap_baseline, "zap_active": self.zap_active}.get(tool)
+        if fn is None:
+            return ScanReport(False, target, [tool], note=f"unknown tool {tool}")
+        return fn(target)
+
+
+# profile → ordered tool list (used by the MCP server + tenant)
+PROFILES: dict[str, list[str]] = {
+    "recon": ["nmap"],
+    "web-baseline": ["nuclei", "zap_baseline"],
+    "web-active": ["nuclei", "zap_active"],
+    "full": ["nmap", "nuclei", "zap_baseline"],
+}
+ACTIVE_PROFILES = {"web-active", "full"}
+
+
+def _as_url(target: str) -> str:
+    return target if "://" in target else f"http://{target}"
+
+
+def _read(path: str) -> str:
+    try:
+        with open(path) as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def _parse_nmap(raw: str, target: str) -> list[Finding]:
+    out: list[Finding] = []
+    for line in raw.splitlines():
+        m = re.match(r"(\d+)/tcp\s+open\s+(\S+)(?:\s+(.*))?", line.strip())
+        if m:
+            port, svc, ver = m.group(1), m.group(2), (m.group(3) or "").strip()
+            out.append(Finding("info", f"open {svc} on :{port}" + (f" — {ver}" if ver else ""),
+                               target, "nmap", evidence=line.strip()))
+        if "SSLv3" in line or "TLSv1.0" in line or "TLSv1.1" in line:
+            out.append(Finding("medium", "legacy TLS protocol offered", target, "nmap", evidence=line.strip()))
+    return out
+
+
+def _parse_nuclei(raw: str, target: str) -> list[Finding]:
+    out: list[Finding] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        info = d.get("info", {})
+        out.append(Finding(str(info.get("severity", "info")).lower(),
+                           info.get("name", d.get("template-id", "finding")),
+                           d.get("matched-at", target), "nuclei",
+                           evidence=str(info.get("description", ""))[:200], ref=d.get("template-id", "")))
+    return out
+
+
+def _parse_zap(raw: str, target: str) -> list[Finding]:
+    out: list[Finding] = []
+    try:
+        d = json.loads(raw)
+    except ValueError:
+        return out
+    _risk = {"3": "high", "2": "medium", "1": "low", "0": "info"}
+    for site in d.get("site", []):
+        for a in site.get("alerts", []):
+            out.append(Finding(_risk.get(str(a.get("riskcode", "0")), "info"),
+                               a.get("name", "alert"), target, "zap",
+                               evidence=str(a.get("desc", ""))[:200], ref=str(a.get("pluginid", ""))))
+    return out

--- a/context_runtime/integrations/runtime_scan_engine.py
+++ b/context_runtime/integrations/runtime_scan_engine.py
@@ -15,9 +15,11 @@ import re
 import shutil
 import subprocess
 import urllib.parse
+import uuid
 from dataclasses import dataclass, field
 
-from ..types import Hit
+# NB: ``Hit`` is imported lazily inside ``Finding.as_hit`` (not at module top) so this engine
+# runs standalone in the slim deploy-scan scanner image without the full context_runtime package.
 
 _SEV_RANK = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
 
@@ -73,7 +75,8 @@ class Finding:
     evidence: str = ""
     ref: str = ""            # CVE / template-id / plugin-id
 
-    def as_hit(self, idx: int) -> Hit:
+    def as_hit(self, idx: int):
+        from ..types import Hit   # lazy: only needed by the CR tenant, not the standalone scanner
         return Hit(chunk_id=f"{self.tool}::{idx}", filename=self.tool, source=self.tool,
                    text=f"[{self.severity.upper()}] {self.name} @ {self.target}"
                         + (f" ({self.ref})" if self.ref else ""),
@@ -180,8 +183,11 @@ class DeploymentScanner:
         self._guard(target)
         if not (self.live and shutil.which("nuclei")):
             return self._sim(target, "nuclei")
-        rc, out, err = self._run(["nuclei", "-u", _as_url(target), "-severity", severity,
-                                  "-jsonl", "-silent", "-duc"])
+        cmd = ["nuclei", "-u", _as_url(target), "-severity", severity, "-jsonl", "-silent", "-duc"]
+        tdir = os.getenv("SCAN_NUCLEI_TEMPLATES")   # pin templates dir (container bakes a fixed path)
+        if tdir:
+            cmd += ["-t", tdir]
+        rc, out, err = self._run(cmd)
         if rc != 0:
             return ScanReport(False, target, ["nuclei"], note=f"nuclei rc={rc}: {err[:140]}")
         return ScanReport(True, target, ["nuclei"], findings=_parse_nuclei(out, target))
@@ -201,13 +207,16 @@ class DeploymentScanner:
         zap_timeout = max(self.timeout, float(os.getenv("SCAN_ZAP_TIMEOUT", "600")))
         if not self.live:
             return self._sim(target, tool)
-        # 1) native ZAP scripts on PATH
+        # 1) native ZAP scripts on PATH. zap-baseline.py writes -J RELATIVE to the ZAP
+        #    working dir (/zap/wrk in the ZAP image), not an absolute path — so pass a
+        #    basename and read it back from that working dir.
         if shutil.which(script):
-            import tempfile
-            report = tempfile.NamedTemporaryFile("r", suffix=".json", delete=False).name
-            rc, _, _ = self._run([script, "-t", url, "-J", report, "-I"], timeout=zap_timeout)
-            return ScanReport(True, target, ["zap"], findings=_parse_zap(_read(report), target),
-                              note=f"{kind} native (rc={rc})")
+            workdir = os.getenv("SCAN_ZAP_WORKDIR", "/zap/wrk")
+            name = f"zap_{uuid.uuid4().hex[:8]}.json"
+            rc, _, _ = self._run([script, "-t", url, "-J", name, "-I"], timeout=zap_timeout)
+            raw = _read(os.path.join(workdir, name)) or _read(name)   # fallback: process cwd
+            return ScanReport(bool(raw) or rc == 0, target, ["zap"],
+                              findings=_parse_zap(raw, target), note=f"{kind} native (rc={rc})")
         # 2) containerized ZAP (zaproxy/zap-stable) — report lands in the mounted /zap/wrk
         image = self._docker_image()
         if image:

--- a/context_runtime/tools/mcp_servers/deploy_scan.py
+++ b/context_runtime/tools/mcp_servers/deploy_scan.py
@@ -1,0 +1,211 @@
+"""deploy_scan — a runtime-DAST MCP server (stdio) for edge-sentinel's deployment plane.
+
+Exposes three tools that scan a **running deployment** (not code/packages) for exploitable
+exposure with nmap + nuclei + ZAP. Scans take minutes, but MCP calls must stay well under the
+~55s SDK ceiling, so the contract is async — start, poll, fetch — never a blocking scan_and_wait:
+
+  * scan_start(target, profile)  → {job_id, state:"running"}      [SIDE-EFFECTING: sends probe
+                                     traffic; gated by the harness ApprovalPolicy]
+  * scan_status(job_id)          → {state, tools_done, elapsed_s}  [readOnly]
+  * scan_results(job_id)         → {summary, findings[]}           [readOnly]
+
+profile ∈ recon(nmap) | web-baseline(nuclei+zap passive) | web-active(nuclei+zap ACTIVE) | full.
+Every scan_start enforces the fail-closed ``SCAN_ALLOWLIST`` scope; an off-scope target is
+refused before any scanner subprocess is spawned. Real tools run when installed + SCAN_LIVE=1;
+otherwise a faithful simulated report lets the whole loop run offline.
+
+Speaks newline-delimited JSON-RPC 2.0 (MCP stdio) matching ``context_runtime.tools.mcp.MCPClient``.
+Background scan threads only mutate the in-memory job table — they never write stdout, so the
+JSON-RPC stream stays clean.
+
+Run:  python -m context_runtime.tools.mcp_servers.deploy_scan
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import uuid
+
+from ...integrations.runtime_scan_engine import (
+    ACTIVE_PROFILES, PROFILES, DeploymentScanner, OutOfScopeError, ScanReport,
+    Finding, host_of, in_scope,
+)
+
+_JOBS: dict[str, dict] = {}
+_LOCK = threading.Lock()
+
+
+def _set(job_id: str, **kw) -> None:
+    with _LOCK:
+        if job_id in _JOBS:
+            _JOBS[job_id].update(kw)
+
+
+def _run_job(job_id: str, target: str, tools: list[str]) -> None:
+    scanner = DeploymentScanner()
+    findings: list[Finding] = []
+    for tool in tools:
+        try:
+            rep = scanner.run_tool(tool, target)
+        except OutOfScopeError as e:      # defence in depth (scan_start already checked)
+            _set(job_id, state="error", error=str(e))
+            return
+        except Exception as e:            # a scanner crash fails the job, not the server
+            _set(job_id, state="error", error=f"{type(e).__name__}: {e}")
+            return
+        findings.extend(rep.findings)
+        with _LOCK:
+            _JOBS[job_id]["tools_done"].append(tool)
+            _JOBS[job_id]["simulated"] = _JOBS[job_id].get("simulated", False) or rep.simulated
+    _set(job_id, state="done", findings=[f.as_dict() for f in findings])
+
+
+# ──────────────────────────── tool implementations ────────────────────────────
+
+
+def scan_start(target: str, profile: str = "web-baseline") -> dict:
+    target = (target or "").strip()
+    if profile not in PROFILES:
+        return {"error": f"unknown profile {profile!r}; choose one of {sorted(PROFILES)}"}
+    if not target:
+        return {"error": "target is required"}
+    if not in_scope(target):
+        return {"error": f"out of scope: {host_of(target)!r} is not in SCAN_ALLOWLIST "
+                         f"(fail-closed — set SCAN_ALLOWLIST to your own hosts)"}
+    job_id = uuid.uuid4().hex[:12]
+    tools = list(PROFILES[profile])
+    with _LOCK:
+        _JOBS[job_id] = {"state": "running", "target": target, "profile": profile,
+                         "tools": tools, "tools_done": [], "findings": None,
+                         "started": time.monotonic(), "simulated": False,
+                         "active": profile in ACTIVE_PROFILES}
+    threading.Thread(target=_run_job, args=(job_id, target, tools), daemon=True).start()
+    return {"job_id": job_id, "state": "running", "profile": profile, "tools": tools,
+            "target": target, "active": profile in ACTIVE_PROFILES}
+
+
+def scan_status(job_id: str) -> dict:
+    with _LOCK:
+        job = _JOBS.get(job_id)
+        if not job:
+            return {"error": f"unknown job_id {job_id!r}"}
+        elapsed = round(time.monotonic() - job["started"], 1)
+        n = len(job["findings"]) if job.get("findings") is not None else None
+        return {"job_id": job_id, "state": job["state"], "profile": job["profile"],
+                "tools_done": list(job["tools_done"]), "tools": list(job["tools"]),
+                "elapsed_s": elapsed, "n_findings": n, "error": job.get("error")}
+
+
+def scan_results(job_id: str) -> dict:
+    with _LOCK:
+        job = _JOBS.get(job_id)
+        if not job:
+            return {"error": f"unknown job_id {job_id!r}"}
+        if job["state"] != "done":
+            return {"job_id": job_id, "state": job["state"], "note": "not ready — keep polling scan_status",
+                    "error": job.get("error")}
+        findings = list(job["findings"] or [])
+        simulated = job.get("simulated", False)
+        target = job["target"]
+    fobjs = [Finding(**f) for f in findings]
+    report = ScanReport(True, target, sorted({f.tool for f in fobjs}), findings=fobjs, simulated=simulated)
+    return {"job_id": job_id, "state": "done", "summary": report.summary(), "findings": findings}
+
+
+# ──────────────────────────── JSON-RPC 2.0 stdio plumbing ────────────────────────────
+
+_TOOLS = [
+    {
+        "name": "scan_start",
+        "description": ("Start a DAST scan of a RUNNING deployment (not code/packages). profile: "
+                        "recon (nmap surface) | web-baseline (nuclei + ZAP passive) | web-active "
+                        "(nuclei + ZAP ACTIVE attack traffic) | full. Returns a job_id; poll "
+                        "scan_status then fetch scan_results. Scope-enforced via SCAN_ALLOWLIST."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {"type": "string", "description": "URL or host to scan (must be allowlisted)"},
+                "profile": {"type": "string", "enum": sorted(PROFILES),
+                            "description": "scan profile (default web-baseline)"},
+            },
+            "required": ["target"],
+        },
+        # NO readOnlyHint → harness treats it as side-effecting → ApprovalPolicy gate.
+        "annotations": {"destructiveHint": False, "openWorldHint": True},
+    },
+    {
+        "name": "scan_status",
+        "description": "Poll a scan job's state (running|done|error), tools completed, and elapsed time.",
+        "inputSchema": {"type": "object", "properties": {"job_id": {"type": "string"}}, "required": ["job_id"]},
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "scan_results",
+        "description": "Fetch a finished scan's findings + severity summary (once scan_status is 'done').",
+        "inputSchema": {"type": "object", "properties": {"job_id": {"type": "string"}}, "required": ["job_id"]},
+        "annotations": {"readOnlyHint": True},
+    },
+]
+
+_IMPL = {"scan_start": scan_start, "scan_status": scan_status, "scan_results": scan_results}
+
+
+def _result(rid, result=None, error=None) -> dict:
+    m: dict = {"jsonrpc": "2.0", "id": rid}
+    if error is not None:
+        m["error"] = error
+    else:
+        m["result"] = result
+    return m
+
+
+def _call(name: str, args: dict) -> dict:
+    fn = _IMPL.get(name)
+    if fn is None:
+        return {"content": [{"type": "text", "text": f"unknown tool: {name}"}], "isError": True}
+    try:
+        data = fn(**args)
+    except TypeError as e:
+        return {"content": [{"type": "text", "text": f"bad arguments: {e}"}], "isError": True}
+    except Exception as e:  # noqa: BLE001
+        return {"content": [{"type": "text", "text": f"{name} error: {e}"}], "isError": True}
+    is_err = isinstance(data, dict) and "error" in data and data.get("error")
+    return {"content": [{"type": "text", "text": json.dumps(data, separators=(",", ":"))}],
+            "structuredContent": data, "isError": bool(is_err)}
+
+
+def _handle(req: dict) -> dict | None:
+    method = req.get("method")
+    rid = req.get("id")
+    params = req.get("params") or {}
+    if method == "initialize":
+        return _result(rid, {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                             "serverInfo": {"name": "deploy-scan", "version": "0.1.0"}})
+    if method == "tools/list":
+        return _result(rid, {"tools": _TOOLS})
+    if method == "tools/call":
+        return _result(rid, _call(params.get("name"), params.get("arguments") or {}))
+    if rid is not None:
+        return _result(rid, error={"code": -32601, "message": f"method not found: {method}"})
+    return None
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception:  # noqa: BLE001
+            continue
+        resp = _handle(req)
+        if resp is not None:
+            sys.stdout.write(json.dumps(resp) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/context_runtime/tools/mcp_servers/deploy_scan.py
+++ b/context_runtime/tools/mcp_servers/deploy_scan.py
@@ -28,10 +28,16 @@ import threading
 import time
 import uuid
 
-from ...integrations.runtime_scan_engine import (
-    ACTIVE_PROFILES, PROFILES, DeploymentScanner, OutOfScopeError, ScanReport,
-    Finding, host_of, in_scope,
-)
+try:  # in-package (context_runtime) …
+    from ...integrations.runtime_scan_engine import (
+        ACTIVE_PROFILES, PROFILES, DeploymentScanner, OutOfScopeError, ScanReport,
+        Finding, host_of, in_scope,
+    )
+except ImportError:  # … or vendored flat next to this file in the deploy-scan image
+    from runtime_scan_engine import (  # type: ignore
+        ACTIVE_PROFILES, PROFILES, DeploymentScanner, OutOfScopeError, ScanReport,
+        Finding, host_of, in_scope,
+    )
 
 _JOBS: dict[str, dict] = {}
 _LOCK = threading.Lock()
@@ -193,6 +199,7 @@ def _handle(req: dict) -> dict | None:
 
 
 def main() -> None:
+    """stdio transport (default) — one JSON-RPC message per line."""
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -207,5 +214,45 @@ def main() -> None:
             sys.stdout.flush()
 
 
+def serve_http(host: str = "0.0.0.0", port: int = 8770) -> None:
+    """HTTP transport — one JSON-RPC request per POST, matching MCPClient.http. Used when the
+    scanner runs as a networked compose/k8s service reached over the shared network."""
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def _send(self, code: int, payload: dict | None) -> None:
+            body = (json.dumps(payload) if payload is not None else "").encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+
+        def do_GET(self):  # lightweight health/readiness probe
+            self._send(200, {"ok": True, "server": "deploy-scan", "tools": [t["name"] for t in _TOOLS]})
+
+        def do_POST(self):
+            try:
+                n = int(self.headers.get("Content-Length", 0))
+                req = json.loads(self.rfile.read(n) or b"{}")
+            except Exception:  # noqa: BLE001
+                self._send(400, {"jsonrpc": "2.0", "error": {"code": -32700, "message": "parse error"}})
+                return
+            resp = _handle(req)
+            self._send(200, resp if resp is not None else {})
+
+        def log_message(self, *a):  # keep the JSON-RPC stream / logs quiet
+            pass
+
+    ThreadingHTTPServer((host, port), Handler).serve_forever()
+
+
 if __name__ == "__main__":
-    main()
+    if "--http" in sys.argv:
+        i = sys.argv.index("--http")
+        bind = sys.argv[i + 1] if i + 1 < len(sys.argv) else "0.0.0.0:8770"
+        h, _, p = bind.rpartition(":")
+        serve_http(h or "0.0.0.0", int(p or "8770"))
+    else:
+        main()

--- a/examples/runtime_scan.py
+++ b/examples/runtime_scan.py
@@ -1,0 +1,139 @@
+"""runtime-scan × Context Runtime — deployment-DAST tenant, offline end-to-end.
+
+Shows edge-sentinel's *runtime* security plane (complement of the supply_chain/Trivy plane):
+Context Runtime plans which DAST bundle to run against a running deployment, runs it via the
+deploy_scan tools (nmap/nuclei/ZAP — simulated when the binaries aren't installed), and learns
+the cheapest scan bundle that still catches the exposure. Passive scans auto-approve; the ZAP
+*active* scan is approval-gated. Every target is scope-checked against SCAN_ALLOWLIST first.
+
+    python examples/runtime_scan.py
+"""
+from __future__ import annotations
+
+import os
+import time
+
+# Scope: only these (owned) hosts may be scanned. Fail-closed — unset ⇒ nothing scans.
+os.environ.setdefault(
+    "SCAN_ALLOWLIST",
+    "192.168.40.105,vibexgen.io,*.vibexgen.io,telegrambot.ai,*.telegrambot.ai,learnerbot.ai,*.learnerbot.ai",
+)
+
+from context_runtime.integrations.runtime_scan import (  # noqa: E402
+    DEFAULT_BUNDLES, RuntimeScanTenant, ScanBundle, _scan_bandit, mount_deploy_scan,
+    passive_only_approver, reward_scan, scan_bucket,
+)
+from context_runtime.tools.base import ApprovalPolicy, ToolRegistry  # noqa: E402
+
+# A stream of OWNED deployment targets. Hidden truth: each target class has ONE decisive tool
+# (tls→nmap, web_cve→nuclei, injection→zap_active). The tenant must learn the cheapest bundle
+# that includes it — e.g. escalate to the (gated) active scan ONLY for injection-shaped targets.
+TARGETS = [
+    "192.168.40.105",                         # tls        (bare host)
+    "learnerbot.ai",                          # tls
+    "https://vibexgen.io/",                   # web_cve
+    "https://telegrambot.ai/",                # web_cve
+    "https://app.telegrambot.ai/login",       # injection  (needs active)
+    "https://auth.vibexgen.io/api",           # injection
+]
+
+BASELINE = ScanBundle(("nmap", "nuclei", "zap_baseline"))   # "thorough passive" — misses injection
+
+
+def _caught(result) -> bool:
+    """Grounded in the actual scan output: a real exposure = a high/critical finding."""
+    return any(f.severity in ("high", "critical") for f in result.report.findings)
+
+
+def _bundle_cost(b: ScanBundle) -> float:
+    from context_runtime.integrations.runtime_scan import _bundle_cost as bc
+    return bc(b)
+
+
+def main() -> None:
+    tenant = RuntimeScanTenant(bandit=_scan_bandit(epsilon=0.2))
+    print("scanner binaries available:", tenant.scanner.available(), "(sim fallback otherwise)\n")
+
+    print("── one-shot: classify + scan each target ──")
+    for t in TARGETS:
+        r = tenant.scan(t)
+        print(f"  {t:42s} class={r.bucket:9s} bundle={r.bundle.key:24s} "
+              f"max_sev={r.max_severity:8s} findings={len(r.report.findings)}")
+        tenant.record_outcome(t, _caught(r))
+    print()
+
+    # ── train the bandit, then compare learned policy vs the thorough-passive baseline ──
+    print("── learning: cheapest bundle that still catches the exposure ──")
+    tenant = RuntimeScanTenant(bandit=_scan_bandit(epsilon=0.2))
+    for _ in range(60):
+        for t in TARGETS:
+            r = tenant.scan(t)
+            tenant.record_outcome(t, _caught(r))
+
+    def evaluate(select_bundle):
+        caught = cost = 0.0
+        for t in TARGETS:
+            bucket = scan_bucket(t)
+            bundle = select_bundle(bucket)
+            # sim truth: exposure caught iff bundle holds the class's decisive tool
+            decisive = {"tls": "nmap", "web_cve": "nuclei", "injection": "zap_active"}[bucket]
+            ok = decisive in bundle.tools
+            caught += 1.0 if ok else 0.0
+            cost += _bundle_cost(bundle)
+        return caught / len(TARGETS), cost / len(TARGETS)
+
+    learned_policy = tenant.policy()
+    learned_catch, learned_cost = evaluate(lambda b: _bundle_by_key(learned_policy[b]))
+    base_catch, base_cost = evaluate(lambda b: BASELINE)
+
+    print("  learned policy (per target class):")
+    for bucket, key in sorted(learned_policy.items()):
+        print(f"    {bucket:9s} → {key}")
+    print(f"\n  catch-rate   learned={learned_catch:.2f}   baseline(thorough-passive)={base_catch:.2f}")
+    print(f"  avg cost     learned={learned_cost:.2f}    baseline={base_cost:.2f}")
+    print(f"  → CR escalates to the gated ACTIVE scan only where a passive bundle can't see the bug,\n"
+          f"    and stays cheap elsewhere (delta catch +{learned_catch - base_catch:.2f}).\n")
+
+    _mcp_demo()
+
+
+def _bundle_by_key(key: str) -> ScanBundle:
+    for b in DEFAULT_BUNDLES:
+        if b.key == key:
+            return b
+    return BASELINE
+
+
+def _mcp_demo() -> None:
+    """Prove the deploy_scan MCP server + approval gate end-to-end (async start/poll/results)."""
+    print("── deploy_scan MCP server: async scan + approval gate ──")
+    reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=passive_only_approver))
+    client, names = mount_deploy_scan(reg)
+    try:
+        print("  mounted MCP tools:", names)
+
+        # passive scan → auto-approved by passive_only_approver
+        start = reg.run("scan.scan_start", {"target": "https://vibexgen.io/", "profile": "web-baseline"})
+        job = (start.data or {}).get("job_id")
+        print(f"  scan_start(web-baseline) → {start.text[:80]}")
+        for _ in range(20):
+            st = reg.run("scan.scan_status", {"job_id": job})
+            if (st.data or {}).get("state") in ("done", "error"):
+                break
+            time.sleep(0.3)
+        res = reg.run("scan.scan_results", {"job_id": job})
+        print(f"  scan_results → summary={ (res.data or {}).get('summary') }")
+
+        # active scan without a human approver → BLOCKED by the ApprovalPolicy
+        blocked = reg.run("scan.scan_start", {"target": "https://app.telegrambot.ai/login", "profile": "web-active"})
+        print(f"  scan_start(web-active, no approver) → {'BLOCKED: ' + (blocked.error or '') if not blocked.ok else blocked.text}")
+
+        # out-of-scope target → refused before any scanner runs
+        oos = reg.run("scan.scan_start", {"target": "https://example.com/", "profile": "recon"})
+        print(f"  scan_start(example.com, off-scope) → isError={not oos.ok or 'out of scope' in (oos.text or '')}: {oos.text[:70]}")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_runtime_scan.py
+++ b/tests/test_runtime_scan.py
@@ -1,0 +1,143 @@
+"""Hermetic tests for the runtime-DAST plane (deploy_scan MCP + RuntimeScanTenant).
+
+No live scanners, no network: SCAN_LIVE is unset so DeploymentScanner returns simulated
+findings. Covers scope (fail-closed), the async MCP job lifecycle, the approval gate, and reward.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from context_runtime.integrations.runtime_scan import (
+    DEFAULT_BUNDLES, DeploymentScanner, OutOfScopeError, RuntimeScanTenant, ScanBundle,
+    host_of, in_scope, mount_deploy_scan, passive_only_approver, reward_scan, scan_bucket,
+)
+from context_runtime.tools.base import ApprovalPolicy, ToolRegistry
+
+ALLOW = ["192.168.40.105", "vibexgen.io", "*.vibexgen.io"]
+
+
+# ── scope: fail-closed allowlist ────────────────────────────────────────────
+def test_scope_fail_closed_when_empty():
+    assert in_scope("vibexgen.io", []) is False
+    assert in_scope("https://vibexgen.io/x", None if False else []) is False
+
+
+def test_scope_exact_and_wildcard():
+    assert in_scope("192.168.40.105", ALLOW) is True
+    assert in_scope("https://vibexgen.io/login?q=1", ALLOW) is True
+    assert in_scope("auth.vibexgen.io", ALLOW) is True          # *.vibexgen.io
+    assert in_scope("https://app.vibexgen.io/api", ALLOW) is True
+    assert in_scope("example.com", ALLOW) is False
+    assert in_scope("notvibexgen.io", ALLOW) is False           # no false suffix match
+
+
+def test_host_of():
+    assert host_of("https://a.b.c/x?y=1") == "a.b.c"
+    assert host_of("a.b.c:8080") == "a.b.c"
+    assert host_of("A.B.C") == "a.b.c"
+
+
+def test_scanner_guard_refuses_off_scope():
+    s = DeploymentScanner(allowlist=ALLOW, live=False)
+    with pytest.raises(OutOfScopeError):
+        s.nmap_scan("example.com")
+    # in-scope simulated scan works
+    rep = s.nmap_scan("192.168.40.105")
+    assert rep.ok and rep.simulated
+
+
+def test_tenant_refuses_off_scope():
+    t = RuntimeScanTenant(scanner=DeploymentScanner(allowlist=ALLOW, live=False))
+    with pytest.raises(OutOfScopeError):
+        t.scan("https://example.com/")
+
+
+# ── simulated findings: decisive tool surfaces the class's exposure ─────────
+def test_sim_decisive_tool_surfaces_exposure():
+    s = DeploymentScanner(allowlist=ALLOW, live=False)
+    # injection target: only the active scan surfaces the high-sev bug
+    inj = "https://vibexgen.io/login"
+    assert scan_bucket(inj) == "injection"
+    passive = s.nuclei_scan(inj)
+    assert not any(f.severity in ("high", "critical") for f in passive.findings)
+    active = s.zap_active(inj)
+    assert any(f.severity == "high" for f in active.findings)
+    # tls target: nmap is decisive
+    assert any(f.severity == "high" for f in s.nmap_scan("192.168.40.105").findings)
+
+
+# ── reward: cheaper sufficient bundle scores higher; miss = 0 ───────────────
+def test_reward_monotonic():
+    cheap = ScanBundle(("nmap",))
+    dear = ScanBundle(("nuclei", "zap_active"))
+    assert reward_scan(True, cheap) > reward_scan(True, dear) > 0
+    assert reward_scan(False, cheap) == 0.0
+
+
+# ── deploy_scan MCP server: async lifecycle + scope + approval gate ─────────
+def _mounted(approver=passive_only_approver):
+    os.environ["SCAN_ALLOWLIST"] = ",".join(ALLOW)
+    reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=approver))
+    client, names = mount_deploy_scan(reg)
+    return reg, client, names
+
+
+def _drive(reg, target, profile):
+    start = reg.run("scan.scan_start", {"target": target, "profile": profile})
+    assert start.ok, start.error
+    job = (start.data or {}).get("job_id")
+    assert job
+    for _ in range(50):
+        st = reg.run("scan.scan_status", {"job_id": job})
+        if (st.data or {}).get("state") in ("done", "error"):
+            break
+        time.sleep(0.1)
+    return reg.run("scan.scan_results", {"job_id": job})
+
+
+def test_mcp_async_lifecycle():
+    reg, client, names = _mounted(approver=lambda a: True)   # allow active for the lifecycle test
+    try:
+        assert {"scan.scan_start", "scan.scan_status", "scan.scan_results"} <= set(names)
+        res = _drive(reg, "https://vibexgen.io/login", "web-active")
+        data = res.data or {}
+        assert data.get("state") == "done"
+        assert data["summary"]["total"] >= 1
+        assert data["summary"]["max_severity"] in ("high", "critical")   # active caught injection
+    finally:
+        client.close()
+
+
+def test_mcp_approval_gate_blocks_active():
+    reg, client, _ = _mounted(approver=passive_only_approver)
+    try:
+        # passive auto-approved
+        ok = reg.run("scan.scan_start", {"target": "https://vibexgen.io/", "profile": "web-baseline"})
+        assert ok.ok
+        # active blocked (no human approver granted it)
+        blocked = reg.run("scan.scan_start", {"target": "https://vibexgen.io/login", "profile": "web-active"})
+        assert not blocked.ok and "approval" in (blocked.error or "").lower()
+    finally:
+        client.close()
+
+
+def test_mcp_off_scope_refused():
+    reg, client, _ = _mounted(approver=lambda a: True)   # even with blanket approval…
+    try:
+        r = reg.run("scan.scan_start", {"target": "https://example.com/", "profile": "recon"})
+        # …scope is enforced inside the tool: returns an error result, no job created
+        assert (r.data or {}).get("error") and "scope" in r.data["error"].lower()
+    finally:
+        client.close()
+
+
+def test_mcp_unknown_profile():
+    reg, client, _ = _mounted(approver=lambda a: True)
+    try:
+        r = reg.run("scan.scan_start", {"target": "vibexgen.io", "profile": "nope"})
+        assert (r.data or {}).get("error") and "profile" in r.data["error"].lower()
+    finally:
+        client.close()


### PR DESCRIPTION
Adds the **runtime/deployment scanning plane** — the complement of `supply_chain` (Trivy/Syft on images+lockfiles): scans a RUNNING deployment for exploitable exposure.

- `integrations/runtime_scan_engine.py` — `DeploymentScanner` (nmap + nuclei + ZAP, faithful simulated fallback), fail-closed `SCAN_ALLOWLIST` scope, output parsers. nmap defaults to top-1000 + always includes an explicit `host:PORT` + `SCAN_NMAP_PORTS` override. Stdlib + `Hit` only (runs standalone in the scanner image).
- `tools/mcp_servers/deploy_scan.py` — async MCP server (`scan_start`/`scan_status`/`scan_results`) respecting the ~55s call ceiling; stdio **and** HTTP transports; background jobs never touch stdout.
- `integrations/runtime_scan.py` — CR tenant: `ScanBundle` bandit arm + reward (catch the exposure at cheapest scan cost), `mount_deploy_scan` under `ApprovalPolicy`, `passive_only_approver` (active scans gated).
- `examples/runtime_scan.py` + `tests/test_runtime_scan.py` (11 tests).

Invariants: scope is fail-closed; intrusive (active) scans are approval-gated. Deployed live in the redevops agentic-os-stack (edge-sentinel reaches this over MCP/HTTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)