### PR TITLE
accel(v0.3.0): wire cuVS + cuDF behind the live retrieval/temporal interfaces

### DIFF
--- a/context_runtime/accel/__init__.py
+++ b/context_runtime/accel/__init__.py
@@ -1,0 +1,17 @@
+"""Accelerator backends — optional GPU implementations of runtime operations (v0.3.0).
+
+The runtime stays **accelerator-aware, not GPU-dependent**: the CPU path is always the reference and the
+fallback, and an accelerator is a *costed capability* the runtime selects only when a measured crossover
+says it pays. Nothing here is on by default — with no ``CR_ACCEL`` env flag, or no GPU, or a corpus below
+the crossover, every call runs exactly the CPU code it always did.
+
+Backends (benchmarked in `context-runtime` `benchmarks/wikimedia/accelerators`, FINDINGS_v0.3.0):
+  * ``cuvs_ann``      — cuVS CAGRA ANN for semantic retrieval. Crossover ~12k vectors; 36× query speedup
+                        at 200k. Approximate (recall ~0.96 vs exact), so it is opt-in for large corpora.
+  * ``cudf_temporal`` — cuDF for temporal/evidence change-set processing. Crossover ~10^6 rows; exact
+                        (byte-identical to the pandas/Python reference).
+
+The seam is ``selector.decide(kind, n)`` → an ``AccelDecision``; a store calls it, and on ``use_gpu`` routes
+to the backend, otherwise runs its existing CPU path. Every decision carries a ``reason`` for EXPLAIN.
+"""
+from .selector import AccelDecision, decide, gpu_available  # noqa: F401

--- a/context_runtime/accel/cudf_temporal.py
+++ b/context_runtime/accel/cudf_temporal.py
@@ -1,0 +1,61 @@
+"""cuDF backend for temporal/evidence change-set processing (the arm-H workload).
+
+``TemporalStore.changes`` answers "what began or ended validity in [since, until)?" over a body of facts.
+The reference is a Python loop; past the ~10^6-fact crossover a dataframe reduction wins. This computes the
+**identical** result (same records, same order) with a dataframe module — cudf on the GPU, or pandas on the
+CPU (used by the equivalence test, so the vectorised logic is checked without a GPU).
+
+Exactness detail: the Python reference appends, per fact in order, a "began" record then an "ended" record,
+then stable-sorts by ``at``. We reproduce that by tagging each record with a sequence key (2·i / 2·i+1) and
+sorting by ``(at, seq)`` — a stable sort by ``at`` that breaks ties exactly as the loop does. ISO-8601
+timestamps compare lexically, matching the reference's string comparisons.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def _changes_df(xf, valid_from: Sequence[str], valid_to: Sequence, subject: Sequence[str],
+                predicate: Sequence[str], obj: Sequence[str], text: Sequence[str],
+                *, since: str, until: str, k: int) -> list[dict]:
+    """Compute the change list with dataframe module ``xf`` (pandas or cudf)."""
+    n = len(valid_from)
+    seq = list(range(n))
+    df = xf.DataFrame({
+        "seq": seq, "vf": list(valid_from), "vt": list(valid_to),
+        "subject": list(subject), "predicate": list(predicate), "obj": list(obj), "text": list(text),
+    })
+    began = df[(df["vf"] >= since) & (df["vf"] < until)].copy()
+    began["at"] = began["vf"]
+    began["change"] = "began"
+    began["order"] = began["seq"] * 2
+
+    ended = df[df["vt"].notnull() & (df["vt"] >= since) & (df["vt"] < until)].copy()
+    ended["at"] = ended["vt"]
+    ended["change"] = "ended"
+    ended["order"] = ended["seq"] * 2 + 1
+
+    cols = ["at", "change", "text", "subject", "predicate", "obj", "order"]
+    both = xf.concat([began[cols], ended[cols]], ignore_index=True)
+    both = both.sort_values(["at", "order"])            # stable-by-at, tie-break as the loop does
+    try:
+        both = both.to_pandas()                          # cudf → host
+    except AttributeError:
+        pass
+    out = [{"at": r.at, "change": r.change, "fact": r.text, "subject": r.subject,
+            "predicate": r.predicate, "object": r.obj}
+           for r in both.itertuples(index=False)]
+    return out[:k] if k > 0 else out
+
+
+def changes_gpu(valid_from, valid_to, subject, predicate, obj, text, *, since, until, k) -> list[dict]:
+    import cudf
+    return _changes_df(cudf, valid_from, valid_to, subject, predicate, obj, text,
+                       since=since, until=until, k=k)
+
+
+def changes_cpu_df(valid_from, valid_to, subject, predicate, obj, text, *, since, until, k) -> list[dict]:
+    """pandas equivalent — the reference for the GPU path, and what the no-GPU equivalence test runs."""
+    import pandas as pd
+    return _changes_df(pd, valid_from, valid_to, subject, predicate, obj, text,
+                       since=since, until=until, k=k)

--- a/context_runtime/accel/cuvs_ann.py
+++ b/context_runtime/accel/cuvs_ann.py
@@ -1,0 +1,45 @@
+"""cuVS CAGRA backend for semantic retrieval (the winning arm-I backend).
+
+Wraps a matrix of L2-normalised embeddings in a cuVS CAGRA graph index and answers top-k cosine queries on
+the GPU. The neighbour *set* is approximate (recall ~0.96 vs exact — hence opt-in, for corpora past the
+~12k crossover where the 36× query speedup is worth it); the returned **scores are exact**, recomputed as
+the true inner product of each returned neighbour, so ranking among the returned set is faithful.
+
+All GPU imports are lazy and every entry point raises cleanly on any failure, so the caller can fall back
+to its CPU path. This module imports fine on a host with no GPU / no cuVS.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+class CuvsAnnIndex:
+    """A built CAGRA index over one embedding matrix. Rebuild by constructing a new instance."""
+
+    def __init__(self, mat: np.ndarray):
+        import cupy as cp
+        from cuvs.neighbors import cagra
+        self._cp = cp
+        self._cagra = cagra
+        self._n = int(mat.shape[0])
+        self._mat_dev = cp.asarray(np.ascontiguousarray(mat, dtype=np.float32))   # kept for exact rescoring
+        params = cagra.IndexParams(graph_degree=64, intermediate_graph_degree=128)
+        self._index = cagra.build(params, self._mat_dev)
+
+    @property
+    def size(self) -> int:
+        return self._n
+
+    def query(self, qv: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
+        """Return (indices, scores) for the top-``k`` neighbours of ``qv``. Scores are exact cosine
+        (inner product on normalised vectors); indices are the approximate CAGRA neighbours."""
+        cp, cagra = self._cp, self._cagra
+        k = max(1, min(int(k), self._n))
+        qd = cp.asarray(np.ascontiguousarray(qv, dtype=np.float32).reshape(1, -1))
+        sp = cagra.SearchParams(itopk_size=256, search_width=8)
+        _, idx = cagra.search(sp, self._index, qd, k)
+        idx = cp.asarray(idx).reshape(-1)
+        exact_scores = self._mat_dev[idx] @ qd.reshape(-1)          # true cosine for the returned set
+        order = cp.argsort(-exact_scores)                            # rank by exact score
+        idx, exact_scores = idx[order], exact_scores[order]
+        return cp.asnumpy(idx).astype(int), cp.asnumpy(exact_scores).astype(float)

--- a/context_runtime/accel/selector.py
+++ b/context_runtime/accel/selector.py
@@ -1,0 +1,81 @@
+"""Accelerator selection — the costed-capability decision the roadmap calls for.
+
+``decide(kind, n)`` answers one question: for an operation of this kind over ``n`` items, is the GPU backend
+worth choosing right now? It is **fail-closed to the CPU**: unless the master switch is on, the library and
+a GPU are actually present, and ``n`` is past the measured crossover, the answer is "use the CPU" — so the
+default install, a CPU-only host, and a small workload all behave exactly as before.
+
+Crossovers come from the real benchmark (FINDINGS_v0.3.0_accelerators): ANN retrieval pays above ~12k
+vectors, temporal/evidence dataframe processing above ~10^6 rows. Both are overridable by env for tuning.
+Every decision carries a human ``reason`` so EXPLAIN can show *why* a backend was (not) selected.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Measured crossover defaults (rows/vectors) — below these the CPU wins, so we do not accelerate.
+_ANN_MIN = int(os.getenv("CR_ACCEL_ANN_MIN", "12000"))
+_TEMPORAL_MIN = int(os.getenv("CR_ACCEL_TEMPORAL_MIN", "1000000"))
+_CROSSOVER = {"ann": _ANN_MIN, "temporal": _TEMPORAL_MIN}
+_LIB = {"ann": "cuvs", "temporal": "cudf"}
+
+_gpu_cache: bool | None = None
+
+
+@dataclass(frozen=True)
+class AccelDecision:
+    """The outcome of a selection. ``use_gpu`` is the only thing a caller must honour; ``backend`` and
+    ``reason`` are for EXPLAIN/observability."""
+    use_gpu: bool
+    kind: str
+    n: int
+    backend: str          # "cpu" | "cuvs" | "cudf"
+    reason: str
+
+    def __bool__(self) -> bool:
+        return self.use_gpu
+
+
+def _flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _enabled(kind: str) -> bool:
+    """Master switch ``CR_ACCEL`` turns the whole thing on; ``CR_ACCEL_ANN`` / ``CR_ACCEL_TEMPORAL`` can
+    enable one kind on their own. Off by default → nothing changes."""
+    return _flag("CR_ACCEL") or _flag(f"CR_ACCEL_{kind.upper()}")
+
+
+def gpu_available() -> bool:
+    """True iff a CUDA device is visible via cupy. Cached; never raises (a missing lib → False → CPU)."""
+    global _gpu_cache
+    if _gpu_cache is None:
+        try:
+            import cupy as cp
+            _gpu_cache = cp.cuda.runtime.getDeviceCount() > 0
+        except Exception:
+            _gpu_cache = False
+    return _gpu_cache
+
+
+def _lib_importable(name: str) -> bool:
+    import importlib.util
+    return importlib.util.find_spec(name) is not None
+
+
+def decide(kind: str, n: int) -> AccelDecision:
+    """Select CPU vs GPU for an operation of ``kind`` ("ann"|"temporal") over ``n`` items."""
+    backend = _LIB.get(kind, "cpu")
+    cpu = lambda why: AccelDecision(False, kind, n, "cpu", why)  # noqa: E731
+
+    if not _enabled(kind):
+        return cpu("accelerator disabled (set CR_ACCEL=1)")
+    if not gpu_available():
+        return cpu("no CUDA device — CPU is the fallback")
+    if not _lib_importable(backend):
+        return cpu(f"{backend} not installed — CPU is the fallback")
+    threshold = _CROSSOVER.get(kind, 0)
+    if n < threshold:
+        return cpu(f"n={n} below {kind} crossover {threshold} — CPU is faster here")
+    return AccelDecision(True, kind, n, backend, f"n={n} ≥ crossover {threshold} — {backend} selected")

--- a/context_runtime/adapters/store_semantic.py
+++ b/context_runtime/adapters/store_semantic.py
@@ -88,6 +88,9 @@ class SemanticRetriever:
         self.docs: list[dict] = list(docs or [])
         self._emb = None      # numpy matrix [n_docs, dim]
         self._emb_n = -1
+        self._ann = None      # optional cuVS index over self._emb (built on demand, past the crossover)
+        self._ann_n = -1
+        self.last_backend = "cpu"   # which retrieval backend the last search used (for EXPLAIN)
 
     @property
     def available(self) -> bool:
@@ -102,6 +105,7 @@ class SemanticRetriever:
                                   "text": fp.read_text(errors="ignore"), "created_at": None})
                 n += 1
         self._emb = None  # invalidate
+        self._ann = None  # invalidate any cuVS index built over the old matrix
         return {"files": n, "chunks": n}
 
     def _matrix(self):
@@ -120,16 +124,41 @@ class SemanticRetriever:
         mat = self._matrix()
         if mat is None:
             return []
-        import numpy as np
         qv = _embed([query])[0]
+        # Accelerator-aware retrieval: past the ~12k crossover an opt-in cuVS index answers the ANN on the
+        # GPU (36× query speedup at 200k); below it, or with the accelerator off / no GPU, the exact numpy
+        # path runs unchanged. A top-all query (k<=0) and any GPU error both fall back to the CPU path.
+        if k and k > 0:
+            from ..accel import decide
+            d = decide("ann", int(mat.shape[0]))
+            if d.use_gpu:
+                try:
+                    hits = self._search_cuvs(mat, qv, k)
+                    self.last_backend = d.backend
+                    return hits
+                except Exception:
+                    pass  # fall through to the CPU reference — never fail because of the accelerator
+        self.last_backend = "cpu"
+        return self._search_cpu(mat, qv, k)
+
+    def _hit(self, i: int, score: float) -> Hit:
+        d = self.docs[i]
+        return Hit(chunk_id=d["chunk_id"], filename=d["filename"], text=d["text"],
+                   score=score, created_at=d.get("created_at"), source=self.source)
+
+    def _search_cpu(self, mat, qv, k: int) -> list[Hit]:
+        import numpy as np
         sims = mat @ qv  # cosine (both normalized)
         order = np.argsort(-sims)[: max(k, 0) or len(sims)]
-        out: list[Hit] = []
-        for i in order:
-            d = self.docs[int(i)]
-            out.append(Hit(chunk_id=d["chunk_id"], filename=d["filename"], text=d["text"],
-                           score=float(sims[int(i)]), created_at=d.get("created_at"), source=self.source))
-        return out
+        return [self._hit(int(i), float(sims[int(i)])) for i in order]
+
+    def _search_cuvs(self, mat, qv, k: int) -> list[Hit]:
+        from ..accel.cuvs_ann import CuvsAnnIndex
+        if self._ann is None or self._ann_n != int(mat.shape[0]):
+            self._ann = CuvsAnnIndex(mat)          # build once; rebuild only when the matrix changes
+            self._ann_n = int(mat.shape[0])
+        idx, scores = self._ann.query(qv, k)
+        return [self._hit(int(i), float(s)) for i, s in zip(idx, scores)]
 
     def info(self):
         from ..types import PluginInfo

--- a/context_runtime/adapters/store_temporal.py
+++ b/context_runtime/adapters/store_temporal.py
@@ -115,6 +115,22 @@ class TemporalStore:
 
     def changes(self, query: str = "", *, since: str, until: str, k: int = 20) -> list[dict]:
         """"What changed, and when?" — facts that began or ended validity in ``[since, until)``."""
+        # Accelerator-aware: the pure temporal-window scan (no text filter) is a dataframe reduction, so past
+        # the ~10^6-fact crossover an opt-in cuDF path computes the *identical* change list on the GPU. Below
+        # the crossover, for text-filtered queries, or on any GPU error, the Python reference below runs.
+        if not query:
+            from ..accel import decide
+            d = decide("temporal", len(self._facts))
+            if d.use_gpu:
+                try:
+                    from ..accel.cudf_temporal import changes_gpu
+                    f = self._facts
+                    return changes_gpu([x.valid_from for x in f], [x.valid_to for x in f],
+                                       [x.subject for x in f], [x.predicate for x in f],
+                                       [x.obj for x in f], [x.text() for x in f],
+                                       since=since, until=until, k=k)
+                except Exception:
+                    pass  # fall through to the Python reference — never fail because of the accelerator
         q = _tokens(query)
         out: list[dict] = []
         for f in self._facts:

--- a/tests/test_accel_backends.py
+++ b/tests/test_accel_backends.py
@@ -1,0 +1,137 @@
+"""Tests for the v0.3.0 accelerator backends (context_runtime/accel).
+
+These run on a CPU-only host: the selector is exercised by simulating GPU/library presence, and the cuDF
+logic is validated through its pandas twin against the Python reference (no GPU needed). The GPU-only
+equivalence checks skip cleanly when cupy/cuvs/cudf or a device are absent.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from context_runtime.accel import selector
+from context_runtime.adapters.store_temporal import TemporalStore
+
+
+# ── selector: fail-closed, crossover-gated ──────────────────────────────────────────────────────────
+
+def _reset_gpu_cache():
+    selector._gpu_cache = None
+
+
+def test_decide_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("CR_ACCEL", raising=False)
+    monkeypatch.delenv("CR_ACCEL_ANN", raising=False)
+    d = selector.decide("ann", 10_000_000)
+    assert d.use_gpu is False and d.backend == "cpu"
+    assert "disabled" in d.reason
+
+
+def test_decide_no_gpu_falls_back(monkeypatch):
+    monkeypatch.setenv("CR_ACCEL", "1")
+    monkeypatch.setattr(selector, "gpu_available", lambda: False)
+    d = selector.decide("ann", 10_000_000)
+    assert d.use_gpu is False and d.backend == "cpu"
+    assert "CUDA" in d.reason
+
+
+def test_decide_below_crossover_uses_cpu(monkeypatch):
+    monkeypatch.setenv("CR_ACCEL", "1")
+    monkeypatch.setattr(selector, "gpu_available", lambda: True)
+    monkeypatch.setattr(selector, "_lib_importable", lambda name: True)
+    d = selector.decide("ann", 500)                       # below the 12k crossover
+    assert d.use_gpu is False and "below" in d.reason
+
+
+def test_decide_above_crossover_selects_gpu(monkeypatch):
+    monkeypatch.setenv("CR_ACCEL", "1")
+    monkeypatch.setattr(selector, "gpu_available", lambda: True)
+    monkeypatch.setattr(selector, "_lib_importable", lambda name: True)
+    d = selector.decide("ann", 50_000)                    # above the 12k crossover
+    assert d.use_gpu is True and d.backend == "cuvs"
+
+
+def test_decide_lib_missing_falls_back(monkeypatch):
+    monkeypatch.setenv("CR_ACCEL_TEMPORAL", "1")
+    monkeypatch.setattr(selector, "gpu_available", lambda: True)
+    monkeypatch.setattr(selector, "_lib_importable", lambda name: False)
+    d = selector.decide("temporal", 10_000_000)
+    assert d.use_gpu is False and "not installed" in d.reason
+
+
+# ── cuDF temporal: the dataframe result equals the Python reference exactly ──────────────────────────
+
+def _sample_store() -> TemporalStore:
+    s = TemporalStore()
+    # overlapping validity intervals, some still open (valid_to=None), some ending inside the window,
+    # ties on the same timestamp (to exercise the stable-sort tie-break)
+    s.add("acme", "tier", "gold", valid_from="2026-01-01", valid_to="2026-03-01")
+    s.add("acme", "tier", "platinum", valid_from="2026-03-01", valid_to=None)
+    s.add("beta", "status", "active", valid_from="2026-01-01", valid_to=None)
+    s.add("beta", "status", "churned", valid_from="2026-02-15", valid_to="2026-02-15")
+    s.add("gamma", "plan", "free", valid_from="2025-06-01", valid_to="2026-02-01")
+    s.add("delta", "plan", "pro", valid_from="2026-04-01", valid_to=None)   # outside the window
+    return s
+
+
+def test_cudf_pandas_path_matches_python_reference():
+    pd = pytest.importorskip("pandas")  # noqa: F841
+    from context_runtime.accel.cudf_temporal import changes_cpu_df
+    s = _sample_store()
+    since, until = "2026-01-01", "2026-04-01"
+    reference = s.changes(query="", since=since, until=until, k=100)  # accel off by default → Python loop
+    f = s._facts
+    vectorized = changes_cpu_df([x.valid_from for x in f], [x.valid_to for x in f],
+                                [x.subject for x in f], [x.predicate for x in f],
+                                [x.obj for x in f], [x.text() for x in f],
+                                since=since, until=until, k=100)
+    assert vectorized == reference
+    assert reference and reference == sorted(reference, key=lambda c: c["at"])
+
+
+def test_changes_default_path_unchanged():
+    """With the accelerator off (default), changes() is exactly the Python reference — no behaviour drift."""
+    s = _sample_store()
+    out = s.changes(since="2026-01-01", until="2026-04-01")
+    assert all(c["change"] in ("began", "ended") for c in out)
+    assert [c["at"] for c in out] == sorted(c["at"] for c in out)
+
+
+# ── GPU-only equivalence (skips without a device) ───────────────────────────────────────────────────
+
+def _no_gpu() -> bool:
+    _reset_gpu_cache()
+    return not (importlib.util.find_spec("cupy") and selector.gpu_available())
+
+
+@pytest.mark.skipif(_no_gpu(), reason="no CUDA device / cupy")
+def test_gpu_cudf_changes_equals_reference():
+    pytest.importorskip("cudf")
+    from context_runtime.accel.cudf_temporal import changes_gpu
+    s = _sample_store()
+    since, until = "2026-01-01", "2026-04-01"
+    reference = s.changes(query="", since=since, until=until, k=100)
+    f = s._facts
+    gpu = changes_gpu([x.valid_from for x in f], [x.valid_to for x in f],
+                      [x.subject for x in f], [x.predicate for x in f],
+                      [x.obj for x in f], [x.text() for x in f],
+                      since=since, until=until, k=100)
+    assert gpu == reference
+
+
+@pytest.mark.skipif(_no_gpu(), reason="no CUDA device / cupy")
+def test_gpu_cuvs_preserves_top1_identity():
+    pytest.importorskip("cuvs")
+    import numpy as np
+    from context_runtime.accel.cuvs_ann import CuvsAnnIndex
+    rng = np.random.default_rng(0)
+    mat = rng.standard_normal((2000, 64)).astype("float32")
+    mat /= np.linalg.norm(mat, axis=1, keepdims=True)
+    idx = CuvsAnnIndex(mat)
+    # each corpus vector as its own query → its exact nearest neighbour is itself
+    hits = 0
+    for i in range(0, 2000, 50):
+        ids, _ = idx.query(mat[i], 10)
+        hits += int(i in ids.tolist())
+    assert hits >= 0.9 * len(range(0, 2000, 50))


### PR DESCRIPTION
Promotes the two **winning** accelerator backends from the v0.3.0 benchmark into the live runtime — as optional, crossover-gated, fail-closed-to-CPU implementations behind the existing capability interfaces.

**Principle:** accelerator-aware, not GPU-dependent. With no `CR_ACCEL` flag, no GPU, or a corpus below the measured crossover, every call runs exactly the CPU code it always did. The GPU is a costed capability the runtime *selects* on measured crossover, and it never changes the result.

**What's wired**
- `accel/selector.py` — `decide(kind, n) → AccelDecision`. Fail-closed: master switch off / no CUDA device / lib missing / `n` below crossover (ANN ~12k, temporal ~1M, from FINDINGS_v0.3.0) → CPU. Carries a `reason` for EXPLAIN.
- `accel/cuvs_ann.py` — cuVS CAGRA ANN for `SemanticRetriever` (36× query at 200k; approximate neighbours recall ~0.96, exact rescoring of the returned set).
- `accel/cudf_temporal.py` — cuDF change-set for `TemporalStore.changes`; **byte-identical** to the Python reference (dataframe logic written once so the pandas twin is CPU-testable).
- `store_semantic` / `store_temporal` route to the GPU backend only when `decide()` says so, wrapped so any GPU error falls back to the CPU reference. **Default behaviour unchanged** (all existing store tests green).

**Validation**
- CI (no GPU): selector gating + cuDF==reference (pandas twin) pass; GPU-only equivalence tests skip.
- Real GPU (RTX PRO 5000, RAPIDS 26.8): `cuDF changes_gpu == reference` exactly; cuVS self-identity 40/40 at 2k and 50k vectors.

**Release note:** based off `main` (current v0.2.0 runtime). The accelerator *benchmark* lives on the `v0.3.0` branch; the v0.3.0 release cut unifies both. Not merged here — held for your cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)