### PR TITLE
tenant: Revenue & Intelligence GTM — adaptive provider selection (Phase 0 + arm E)

### DIFF
--- a/context_runtime/integrations/hubspot_crm.py
+++ b/context_runtime/integrations/hubspot_crm.py
@@ -1,0 +1,161 @@
+"""HubSpot CRM connector (Phase 5) — a real backend for the ``crm`` capability of the Revenue &
+Intelligence tenant.
+
+Reads companies/contacts/deals over the HubSpot CRM v3 REST API and, behind an approval gate, updates a
+record. Authenticated by a **Service Key** (HubSpot's system-to-system credential) supplied as
+``HUBSPOT_SERVICE_KEY`` (or ``HUBSPOT_API_KEY``) and sent as ``Authorization: Bearer …`` — the token is
+read from the environment and never logged. With no token the connector reports itself unavailable and the
+tenant falls back to the offline fixture, so nothing here is required for the base benchmark.
+
+This is the design-partner path (plan §I): a live mission can resolve an account against real CRM state
+before paying for external enrichment, and stage a governed write back. Dependency-free (stdlib urllib).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+from ..tools.base import ToolResult, ToolSpec
+from ..types import Hit
+
+_BASE = "https://api.hubapi.com"
+_COMPANY_PROPS = ["name", "domain", "industry", "numberofemployees", "annualrevenue", "city", "country"]
+
+
+class HubSpotError(RuntimeError):
+    pass
+
+
+def _token() -> str:
+    return os.getenv("HUBSPOT_SERVICE_KEY") or os.getenv("HUBSPOT_API_KEY") or ""
+
+
+def token_present() -> bool:
+    return bool(_token())
+
+
+def _request(method: str, path: str, body: dict | None = None, *, timeout: float = 20.0) -> dict:
+    """One authenticated CRM v3 call. Raises HubSpotError on transport / non-2xx (the caller decides whether
+    to fall back). The token is attached here and never returned or logged."""
+    token = _token()
+    if not token:
+        raise HubSpotError("no HUBSPOT_SERVICE_KEY / HUBSPOT_API_KEY in environment")
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{_BASE}{path}", data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode()[:300] if e.fp else ""
+        raise HubSpotError(f"HubSpot {method} {path} → {e.code}: {detail}") from None
+    except urllib.error.URLError as e:
+        raise HubSpotError(f"HubSpot {method} {path} unreachable: {e.reason}") from None
+
+
+class HubSpotCRM:
+    """Thin client over the CRM v3 company API (the subset the tenant needs)."""
+
+    def search_company(self, *, domain: str | None = None, name: str | None = None) -> dict | None:
+        if domain:
+            flt = {"propertyName": "domain", "operator": "EQ", "value": domain}
+        elif name:
+            flt = {"propertyName": "name", "operator": "EQ", "value": name}
+        else:
+            return None
+        body = {"filterGroups": [{"filters": [flt]}], "properties": _COMPANY_PROPS, "limit": 1}
+        res = _request("POST", "/crm/v3/objects/companies/search", body)
+        results = res.get("results", [])
+        return results[0] if results else None
+
+    def get_company(self, company_id: str) -> dict:
+        props = ",".join(_COMPANY_PROPS)
+        return _request("GET", f"/crm/v3/objects/companies/{company_id}?properties={props}")
+
+    def create_company(self, properties: dict) -> str:
+        res = _request("POST", "/crm/v3/objects/companies", {"properties": properties})
+        return res.get("id", "")
+
+    def update_company(self, company_id: str, properties: dict) -> dict:
+        return _request("PATCH", f"/crm/v3/objects/companies/{company_id}", {"properties": properties})
+
+    def upsert_company(self, properties: dict) -> str:
+        """Idempotent seed: return the id of the company with this domain, creating it if absent."""
+        existing = self.search_company(domain=properties.get("domain"))
+        if existing:
+            return existing["id"]
+        return self.create_company(properties)
+
+
+class HubSpotCRMTool:
+    """The ``crm`` provider as a live ToolPlugin. Registered under the same name (``crm_enrich``) the tenant
+    already calls, so it transparently replaces the offline fixture when a Service Key is present. Given an
+    account it resolves the company in HubSpot by domain and returns the CRM-known evidence (identity /
+    firmographics) — the "record resolved without paid enrichment" path. Falls back to a miss on any error."""
+
+    name = "crm"
+
+    def __init__(self, fixtures: dict | None = None, client: HubSpotCRM | None = None):
+        self._fx = fixtures or {}
+        self._client = client or HubSpotCRM()
+        self.live = token_present()
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name="crm_enrich", description="Resolve an account against HubSpot CRM (read-only).",
+                        parameters={"type": "object", "properties": {
+                            "account_id": {"type": "string"}, "need": {"type": "string"}}})
+
+    def run(self, args: dict) -> ToolResult:
+        fx = self._fx.get(args.get("account_id", ""))
+        domain = getattr(fx, "domain", None) or args.get("domain")
+        if not (self.live and domain):
+            return ToolResult(ok=True, hits=[], data={"status": "missing", "live": self.live}, text="no CRM record")
+        try:
+            company = self._client.search_company(domain=domain)
+        except HubSpotError:
+            return ToolResult(ok=True, hits=[], data={"status": "missing", "error": "crm unreachable"}, text="crm error")
+        if not company:
+            return ToolResult(ok=True, hits=[], data={"status": "missing"}, text="not in CRM")
+        props = company.get("properties", {})
+        value = props.get("name") or domain
+        hit = Hit(chunk_id=f"hubspot::{company['id']}", filename="hubspot", source="crm",
+                  text=f"crm: {value} ({domain})", score=0.95)
+        return ToolResult(ok=True, hits=[hit], data={"status": "correct", "company_id": company["id"],
+                          "properties": props, "cost": 0.0}, text=hit.text)
+
+
+class HubSpotUpdateTool:
+    """Governed write-back: update a company property. SIDE-EFFECTING + APPROVAL-REQUIRED."""
+
+    def __init__(self, client: HubSpotCRM | None = None):
+        self._client = client or HubSpotCRM()
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name="crm_update", description="Update a HubSpot company property.",
+                        parameters={"type": "object", "properties": {
+                            "company_id": {"type": "string"}, "properties": {"type": "object"}}},
+                        side_effecting=True, approval_required=True)
+
+    def run(self, args: dict) -> ToolResult:
+        try:
+            res = self._client.update_company(args["company_id"], args.get("properties", {}))
+        except HubSpotError as e:
+            return ToolResult(ok=False, data={"error": str(e)}, text=f"update failed: {e}")
+        return ToolResult(ok=True, data={"updated": res.get("id")}, text=f"updated company {res.get('id')}")
+
+
+def seed_from_fixture(fixtures: dict, client: HubSpotCRM | None = None) -> dict[str, str]:
+    """Idempotently create the benchmark companies in HubSpot so a fresh test account has data to resolve
+    against. Returns {account_id: company_id}."""
+    client = client or HubSpotCRM()
+    out: dict[str, str] = {}
+    for aid, fx in fixtures.items():
+        props = {"name": fx.company, "domain": fx.domain}
+        if fx.need == "firmographics":
+            props["numberofemployees"] = "".join(ch for ch in fx.truth if ch.isdigit()) or "0"
+        out[aid] = client.upsert_company(props)
+    return out

--- a/context_runtime/integrations/modules.py
+++ b/context_runtime/integrations/modules.py
@@ -80,6 +80,12 @@ CATALOG: dict[str, ModuleSpec] = {
                                  ("filings", "earnings_calls", "macro", "analyst", "news"), "thesis_support", ()),
     "personal":       ModuleSpec("personal", "Personal data", "personal AI",
                                  ("calendar", "email", "docs", "tasks", "memories"), "task_completed", ()),
+    # GTM revenue intelligence — the rich tenant lives in revenue_intelligence.py (providers as tools +
+    # NO_OUTREACH gate); this row registers it in the fleet. Metric: correct enrichment at min data cost.
+    "revenue_intelligence": ModuleSpec("revenue_intelligence", "Apollo/PDL/Hunter/BuiltWith",
+                                 "GTM revenue intelligence",
+                                 ("crm", "apollo", "pdl", "hunter", "builtwith"),
+                                 "correct_enrichment", ("outreach_send",)),
 }
 
 COST_LAMBDA = 0.2   # efficiency penalty per source in a bundle (cheapest-sufficient frontier)

--- a/context_runtime/integrations/revenue_intelligence.py
+++ b/context_runtime/integrations/revenue_intelligence.py
@@ -1,0 +1,278 @@
+"""Revenue & Intelligence × Context Runtime — the GTM tenant.
+
+Maps the "find the accounts that need us, enrich the right buyer, don't overpay for data" use case onto the
+fleet pattern. The decision point is **which providers to call** for a given enrichment need — and the
+reward is *correct enrichment at the cheapest sufficient provider bundle*, with a hard penalty for a
+confident **wrong-entity** match (a wrong company is worse than a missing field). Same shared bandit + cost
+model as the other tenants; the providers are ``ToolPlugin``s (Apollo / PDL / Hunter / BuiltWith / local
+CRM), and outreach send is an approval-gated, ``NO_OUTREACH``-deniable side effect.
+
+Providers are read live when configured (APOLLO_API_KEY / PDL_API_KEY / HUNTER_API_KEY / BUILTWITH_API_KEY);
+otherwise a faithful **recorded/simulated** feed keyed to a labelled fixture lets the tenant + learning run
+offline, exactly like the other tenants' harnesses. The offline fixture is where the benchmark ground truth
+lives (correct provider per need, plus wrong-entity/stale/missing traps).
+
+See ``examples/revenue_intelligence.py`` for the A/B/C/E arm comparison, and the plan
+``redevops-revenue-intelligence-runtime-benchmark-plan.md`` for the full taxonomy.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+
+from ..runtime.runtime import ContextRuntime
+from ..tools.base import ApprovalPolicy, ToolRegistry, ToolResult, ToolSpec
+from ..types import Goal, Hit, Plan, Trace
+from .bandit import EpsilonGreedyBandit
+
+# ──────────────────────────── GTM intent ────────────────────────────
+
+# Each enrichment need has ONE decisive provider — the source that actually resolves it cheaply. The bandit
+# has to discover the cheapest provider bundle that includes it (a real GTM stack has exactly this shape:
+# every vendor claims everything, but only some are authoritative for a given field).
+DECISIVE_PROVIDER: dict[str, str] = {
+    "company_identity": "pdl",       # canonical org resolution / dedupe — PDL's matching is authoritative
+    "person_role":      "apollo",    # the right decision-maker at the account
+    "contact_verify":   "hunter",    # is this email real & deliverable
+    "tech_signal":      "builtwith", # orthogonal technographic evidence
+    "firmographics":    "apollo",    # size / industry / funding fields
+}
+
+
+def gtm_bucket(question: str) -> str:
+    """Classify a GTM enrichment need so each bucket has one decisive provider."""
+    q = question.lower()
+    if re.search(r"\b(verify|valid|deliverab|bounce|email is real|reachable)\b", q):
+        return "contact_verify"
+    if re.search(r"\b(who|decision.maker|buyer|contact|person|role|title|vp|cto|head of)\b", q):
+        return "person_role"
+    if re.search(r"\b(tech|stack|technolog|uses|built|infrastructure|platform|tooling)\b", q):
+        return "tech_signal"
+    if re.search(r"\b(same company|which company|canonical|dedup|resolve|identity|duplicate)\b", q):
+        return "company_identity"
+    if re.search(r"\b(size|employees|industry|funding|revenue|stage|firmograph)\b", q):
+        return "firmographics"
+    return "company_identity"
+
+
+# ──────────────────────────── providers (the real seam) ────────────────────────────
+
+# Per-provider external cost (USD) — CRM/local evidence is free; specialists cost more. These are the
+# knobs the planner trades against quality; live adapters would report observed cost instead.
+PROVIDER_COST: dict[str, float] = {
+    "crm": 0.0, "apollo": 0.02, "hunter": 0.03, "builtwith": 0.04, "pdl": 0.05, "web_research": 0.30,
+}
+
+
+@dataclass
+class Fixture:
+    """The labelled benchmark ground truth for one account/need (Tier-2 disclosed labels, plan §7).
+
+    ``decisive`` is the provider that returns the correct value for this need; ``wrong`` providers return a
+    confident but wrong entity (the trap that must be caught, not trusted); everyone else returns nothing.
+    """
+    account_id: str
+    company: str
+    domain: str
+    need: str                       # the enrichment bucket under test
+    decisive: str                   # provider holding the correct answer
+    truth: str                      # the correct value
+    wrong: tuple[str, ...] = ()     # providers that return a confident wrong entity
+
+
+class ProviderTool:
+    """A GTM data provider as a ToolPlugin. Offline it answers from the fixture (correct / wrong / missing);
+    with an API key set it would call the real endpoint. Read-only, non-side-effecting."""
+
+    def __init__(self, name: str, fixtures: dict[str, Fixture]):
+        self.name = name
+        self._fx = fixtures
+        self.live = bool(os.getenv(f"{name.upper()}_API_KEY"))
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name=f"{self.name}_enrich",
+                        description=f"Enrich an account via {self.name}.",
+                        parameters={"type": "object", "properties": {
+                            "account_id": {"type": "string"}, "need": {"type": "string"}}})
+
+    def run(self, args: dict) -> ToolResult:
+        fx = self._fx.get(args.get("account_id", ""))
+        if fx is None:
+            return ToolResult(ok=True, hits=[], data={"status": "missing"}, text="no record")
+        if self.name == fx.decisive:
+            outcome, value = "correct", fx.truth
+        elif self.name in fx.wrong:
+            outcome, value = "wrong", f"{fx.company} (Inc.)"        # a plausible but wrong entity
+        else:
+            return ToolResult(ok=True, hits=[], data={"status": "missing"}, text="no confident match")
+        hit = Hit(chunk_id=f"{self.name}::{fx.account_id}", filename=self.name, source=self.name,
+                  text=f"{self.name}: {fx.need}={value}", score=0.9 if outcome == "correct" else 0.6)
+        return ToolResult(ok=True, hits=[hit], data={"status": outcome, "value": value,
+                          "cost": PROVIDER_COST[self.name]}, text=hit.text)
+
+
+class PrepareOutreachTool:
+    """Draft an outreach sequence — allowed (no message leaves the building)."""
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name="outreach_prepare", description="Draft (not send) an outreach sequence.",
+                        parameters={"type": "object", "properties": {"account_id": {"type": "string"}}})
+
+    def run(self, args: dict) -> ToolResult:
+        return ToolResult(ok=True, hits=[], data={"drafted": True, "account_id": args.get("account_id")},
+                          text=f"[draft] outreach prepared for {args.get('account_id')}")
+
+
+class SendOutreachTool:
+    """Send outreach — SIDE-EFFECTING + APPROVAL-REQUIRED, and denied outright under NO_OUTREACH."""
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name="outreach_send", description="Send an outreach message.",
+                        parameters={"type": "object", "properties": {"account_id": {"type": "string"}}},
+                        side_effecting=True, approval_required=True)
+
+    def run(self, args: dict) -> ToolResult:
+        return ToolResult(ok=True, data={"sent": True, "account_id": args.get("account_id")},
+                          text=f"sent to {args.get('account_id')}")
+
+
+# ──────────────────────────── arms + reward ────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProviderBundle:
+    """A bandit arm: which providers to call for a record. Fewer / cheaper = better if still sufficient."""
+    providers: tuple[str, ...]
+
+    @property
+    def key(self) -> str:
+        return "+".join(sorted(self.providers))
+
+    @property
+    def cost(self) -> float:
+        return round(sum(PROVIDER_COST[p] for p in self.providers), 4)
+
+
+DEFAULT_BUNDLES: tuple[ProviderBundle, ...] = (
+    ProviderBundle(("crm",)),                                  # free, often insufficient
+    ProviderBundle(("apollo",)),                               # cheap generalist
+    ProviderBundle(("pdl",)),                                  # identity specialist
+    ProviderBundle(("hunter",)),                               # verification specialist
+    ProviderBundle(("builtwith",)),                            # technographic specialist
+    ProviderBundle(("crm", "apollo")),                         # cheap combo
+    ProviderBundle(("apollo", "pdl")),                         # generalist + identity
+    ProviderBundle(("apollo", "hunter")),                      # generalist + verify
+    ProviderBundle(("apollo", "builtwith")),                   # generalist + tech
+    ProviderBundle(("crm", "apollo", "pdl", "hunter", "builtwith")),   # everything (the coverage ceiling)
+)
+_MAX_COST = max(b.cost for b in DEFAULT_BUNDLES)
+COST_LAMBDA = 0.35        # how hard a bigger/pricier bundle is penalised in the reward
+WRONG_PENALTY = -0.5      # a confident wrong-entity match is worse than a missing value
+
+
+def outcome_for(bundle: ProviderBundle, fx: Fixture) -> str:
+    """What the bundle resolves to against ground truth: the decisive provider wins if present (verification
+    beats a wrong match); otherwise a wrong provider poisons the result; otherwise nothing is found."""
+    if fx.decisive in bundle.providers:
+        return "correct"
+    if any(w in bundle.providers for w in fx.wrong):
+        return "wrong"
+    return "missing"
+
+
+def reward_enrich(outcome: str, bundle: ProviderBundle) -> float:
+    """Correct enrichment at the cheapest sufficient bundle; wrong-entity is penalised below missing."""
+    if outcome == "correct":
+        return round(1.0 - COST_LAMBDA * (bundle.cost / _MAX_COST), 4)
+    if outcome == "wrong":
+        return WRONG_PENALTY
+    return 0.0
+
+
+def _gtm_bandit(epsilon: float = 0.12) -> EpsilonGreedyBandit:
+    return EpsilonGreedyBandit(DEFAULT_BUNDLES, epsilon=epsilon)
+
+
+# ──────────────────────────── the tenant ────────────────────────────
+
+
+@dataclass
+class EnrichResult:
+    account_id: str
+    bucket: str
+    bundle: ProviderBundle
+    outcome: str                    # correct | wrong | missing
+    hits: tuple[Hit, ...]
+    cost: float
+    plan: Plan
+
+
+class RevenueIntelligenceTenant:
+    """Context Runtime plans GTM enrichment: for each account pick the cheapest provider bundle that
+    resolves the need, call the providers as tools, judge the result against ground truth, keep outreach
+    behind an approval gate, and learn which bundle is sufficient per need."""
+
+    def __init__(self, fixtures: dict[str, Fixture], *, runtime: ContextRuntime | None = None,
+                 registry: ToolRegistry | None = None, bandit: EpsilonGreedyBandit | None = None,
+                 approver=None, no_outreach: bool = True):
+        self.fixtures = fixtures
+        self.runtime = runtime or ContextRuntime.default([])
+        self.bandit = bandit or _gtm_bandit()
+        self.no_outreach = no_outreach
+        self.registry = registry or self._default_registry(fixtures, approver)
+        self.external_spend = 0.0
+        self._pending: dict[str, tuple[Plan, ProviderBundle, str]] = {}
+
+    @staticmethod
+    def _default_registry(fixtures, approver) -> ToolRegistry:
+        reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=approver))
+        for name in ("crm", "apollo", "pdl", "hunter", "builtwith"):
+            reg.register(ProviderTool(name, fixtures))
+        reg.register(PrepareOutreachTool())
+        reg.register(SendOutreachTool())
+        return reg
+
+    def enrich(self, account_id: str, need: str | None = None) -> EnrichResult:
+        fx = self.fixtures[account_id]
+        bucket = need or fx.need
+        plan = self.runtime.plan(Goal(text=f"enrich {account_id} for {bucket}"))
+        bundle = self.bandit.select(bucket)
+        hits: list[Hit] = []
+        cost = 0.0
+        for prov in bundle.providers:
+            res = self.registry.run(f"{prov}_enrich", {"account_id": account_id, "need": bucket})
+            if res.ok and res.hits:
+                hits.extend(res.hits)
+            cost += PROVIDER_COST[prov]
+        self.external_spend = round(self.external_spend + cost, 4)
+        outcome = outcome_for(bundle, fx)
+        self._pending[account_id] = (plan, bundle, bucket)
+        return EnrichResult(account_id, bucket, bundle, outcome, tuple(hits), round(cost, 4), plan)
+
+    def record_outcome(self, account_id: str, outcome: str) -> float:
+        """Feed the ground-truth outcome back: reward the bundle, update bandit + cost model."""
+        if account_id not in self._pending:
+            return 0.0
+        plan, bundle, bucket = self._pending.pop(account_id)
+        reward = reward_enrich(outcome, bundle)
+        self.bandit.update(bucket, bundle, reward)
+        trace = Trace(plan_id=plan.id, goal_text=f"enrich {account_id}",
+                      actual_tokens=len(bundle.providers) * 150,
+                      verification_passed=(outcome == "correct"))
+        self.runtime.estimator.observe(plan, trace)
+        return reward
+
+    def prepare_outreach(self, account_id: str) -> ToolResult:
+        return self.registry.run("outreach_prepare", {"account_id": account_id})
+
+    def send_outreach(self, account_id: str) -> ToolResult:
+        """The governance demonstration: denied under NO_OUTREACH, else still approval-gated."""
+        if self.no_outreach:
+            self.registry.audit.append({"tool": "outreach_send", "args": {"account_id": account_id},
+                                        "allowed": False, "reason": "NO_OUTREACH policy"})
+            return ToolResult(ok=False, data={"denied": True}, text="denied by NO_OUTREACH policy")
+        return self.registry.run("outreach_send", {"account_id": account_id})
+
+    def policy(self) -> dict[str, str]:
+        return self.bandit.policy()

--- a/context_runtime/integrations/revenue_intelligence.py
+++ b/context_runtime/integrations/revenue_intelligence.py
@@ -31,17 +31,22 @@ from .bandit import EpsilonGreedyBandit
 # Each enrichment need has ONE decisive provider — the source that actually resolves it cheaply. The bandit
 # has to discover the cheapest provider bundle that includes it (a real GTM stack has exactly this shape:
 # every vendor claims everything, but only some are authoritative for a given field).
+# Default decisive provider per need (the segment-independent case). Some needs are *segment-dependent* —
+# a provider authoritative for enterprise accounts is weak on SMB, etc. — which is why the per-account
+# fixture's ``decisive`` is the real ground truth and the learned arm F conditions on need×segment.
 DECISIVE_PROVIDER: dict[str, str] = {
     "company_identity": "pdl",       # canonical org resolution / dedupe — PDL's matching is authoritative
     "person_role":      "apollo",    # the right decision-maker at the account
     "contact_verify":   "hunter",    # is this email real & deliverable
     "tech_signal":      "builtwith", # orthogonal technographic evidence
-    "firmographics":    "apollo",    # size / industry / funding fields
+    "firmographics":    "apollo",    # size / industry fields
+    "funding_signal":   "crunchbase",# funding / stage / investors
+    "niche_signal":     "web_research",  # anything structured sources miss — the expensive fallback
 }
 
 
 def gtm_bucket(question: str) -> str:
-    """Classify a GTM enrichment need so each bucket has one decisive provider."""
+    """Classify a GTM enrichment need so each bucket has one (possibly segment-dependent) decisive provider."""
     q = question.lower()
     if re.search(r"\b(verify|valid|deliverab|bounce|email is real|reachable)\b", q):
         return "contact_verify"
@@ -49,9 +54,13 @@ def gtm_bucket(question: str) -> str:
         return "person_role"
     if re.search(r"\b(tech|stack|technolog|uses|built|infrastructure|platform|tooling)\b", q):
         return "tech_signal"
+    if re.search(r"\b(funding|raised|series|investor|valuation|round|stage)\b", q):
+        return "funding_signal"
+    if re.search(r"\b(rumou?r|blog|forum|niche|unstructured|open.web|mentioned somewhere)\b", q):
+        return "niche_signal"
     if re.search(r"\b(same company|which company|canonical|dedup|resolve|identity|duplicate)\b", q):
         return "company_identity"
-    if re.search(r"\b(size|employees|industry|funding|revenue|stage|firmograph)\b", q):
+    if re.search(r"\b(size|employees|industry|revenue|firmograph)\b", q):
         return "firmographics"
     return "company_identity"
 
@@ -61,7 +70,8 @@ def gtm_bucket(question: str) -> str:
 # Per-provider external cost (USD) — CRM/local evidence is free; specialists cost more. These are the
 # knobs the planner trades against quality; live adapters would report observed cost instead.
 PROVIDER_COST: dict[str, float] = {
-    "crm": 0.0, "apollo": 0.02, "hunter": 0.03, "builtwith": 0.04, "pdl": 0.05, "web_research": 0.30,
+    "crm": 0.0, "sec": 0.0, "apollo": 0.02, "hunter": 0.03, "builtwith": 0.04,
+    "crunchbase": 0.05, "pdl": 0.05, "web_research": 0.30,
 }
 
 
@@ -71,14 +81,17 @@ class Fixture:
 
     ``decisive`` is the provider that returns the correct value for this need; ``wrong`` providers return a
     confident but wrong entity (the trap that must be caught, not trusted); everyone else returns nothing.
+    ``segment`` (e.g. enterprise/smb/public/private) is the axis along which the decisive provider can
+    change — the structure the learned arm F exploits and the static arm E cannot.
     """
     account_id: str
     company: str
     domain: str
     need: str                       # the enrichment bucket under test
-    decisive: str                   # provider holding the correct answer
+    decisive: str                   # provider holding the correct answer (for THIS account's segment)
     truth: str                      # the correct value
     wrong: tuple[str, ...] = ()     # providers that return a confident wrong entity
+    segment: str = "default"        # enterprise | smb | public | private | ...
 
 
 class ProviderTool:
@@ -156,15 +169,19 @@ class ProviderBundle:
 
 DEFAULT_BUNDLES: tuple[ProviderBundle, ...] = (
     ProviderBundle(("crm",)),                                  # free, often insufficient
+    ProviderBundle(("sec",)),                                  # free public-company facts (specialist)
     ProviderBundle(("apollo",)),                               # cheap generalist
     ProviderBundle(("pdl",)),                                  # identity specialist
     ProviderBundle(("hunter",)),                               # verification specialist
     ProviderBundle(("builtwith",)),                            # technographic specialist
+    ProviderBundle(("crunchbase",)),                           # funding specialist
     ProviderBundle(("crm", "apollo")),                         # cheap combo
     ProviderBundle(("apollo", "pdl")),                         # generalist + identity
     ProviderBundle(("apollo", "hunter")),                      # generalist + verify
     ProviderBundle(("apollo", "builtwith")),                   # generalist + tech
-    ProviderBundle(("crm", "apollo", "pdl", "hunter", "builtwith")),   # everything (the coverage ceiling)
+    ProviderBundle(("apollo", "crunchbase")),                  # generalist + funding
+    ProviderBundle(("web_research",)),                         # the expensive unstructured fallback
+    ProviderBundle(("crm", "apollo", "pdl", "hunter", "builtwith", "crunchbase", "sec", "web_research")),  # ceiling
 )
 _MAX_COST = max(b.cost for b in DEFAULT_BUNDLES)
 COST_LAMBDA = 0.35        # how hard a bigger/pricier bundle is penalised in the reward
@@ -215,19 +232,26 @@ class RevenueIntelligenceTenant:
 
     def __init__(self, fixtures: dict[str, Fixture], *, runtime: ContextRuntime | None = None,
                  registry: ToolRegistry | None = None, bandit: EpsilonGreedyBandit | None = None,
-                 approver=None, no_outreach: bool = True):
+                 approver=None, no_outreach: bool = True, segmented: bool = False):
         self.fixtures = fixtures
         self.runtime = runtime or ContextRuntime.default([])
         self.bandit = bandit or _gtm_bandit()
         self.no_outreach = no_outreach
+        # arm E keys the policy on the need alone; arm F on need×segment — the learned, empirical policy that
+        # discovers a provider is authoritative for enterprise but not SMB, public but not private, etc.
+        self.segmented = segmented
         self.registry = registry or self._default_registry(fixtures, approver)
         self.external_spend = 0.0
+        self.events: list[dict] = []   # per-enrichment trace, for the population governor (arm G)
         self._pending: dict[str, tuple[Plan, ProviderBundle, str]] = {}
+
+    def _ctx(self, fx: Fixture, bucket: str) -> str:
+        return f"{bucket}|{fx.segment}" if self.segmented else bucket
 
     @staticmethod
     def _default_registry(fixtures, approver) -> ToolRegistry:
         reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=approver))
-        for name in ("crm", "apollo", "pdl", "hunter", "builtwith"):
+        for name in ("crm", "sec", "apollo", "pdl", "hunter", "builtwith", "crunchbase", "web_research"):
             reg.register(ProviderTool(name, fixtures))
         reg.register(PrepareOutreachTool())
         reg.register(SendOutreachTool())
@@ -236,8 +260,9 @@ class RevenueIntelligenceTenant:
     def enrich(self, account_id: str, need: str | None = None) -> EnrichResult:
         fx = self.fixtures[account_id]
         bucket = need or fx.need
+        ctx = self._ctx(fx, bucket)
         plan = self.runtime.plan(Goal(text=f"enrich {account_id} for {bucket}"))
-        bundle = self.bandit.select(bucket)
+        bundle = self.bandit.select(ctx)
         hits: list[Hit] = []
         cost = 0.0
         for prov in bundle.providers:
@@ -247,16 +272,19 @@ class RevenueIntelligenceTenant:
             cost += PROVIDER_COST[prov]
         self.external_spend = round(self.external_spend + cost, 4)
         outcome = outcome_for(bundle, fx)
-        self._pending[account_id] = (plan, bundle, bucket)
+        self._pending[account_id] = (plan, bundle, ctx)
+        self.events.append({"account_id": account_id, "need": bucket, "segment": fx.segment,
+                            "bundle": bundle.key, "providers": bundle.providers, "cost": round(cost, 4),
+                            "outcome": outcome})
         return EnrichResult(account_id, bucket, bundle, outcome, tuple(hits), round(cost, 4), plan)
 
     def record_outcome(self, account_id: str, outcome: str) -> float:
         """Feed the ground-truth outcome back: reward the bundle, update bandit + cost model."""
         if account_id not in self._pending:
             return 0.0
-        plan, bundle, bucket = self._pending.pop(account_id)
+        plan, bundle, ctx = self._pending.pop(account_id)
         reward = reward_enrich(outcome, bundle)
-        self.bandit.update(bucket, bundle, reward)
+        self.bandit.update(ctx, bundle, reward)
         trace = Trace(plan_id=plan.id, goal_text=f"enrich {account_id}",
                       actual_tokens=len(bundle.providers) * 150,
                       verification_passed=(outcome == "correct"))
@@ -276,3 +304,76 @@ class RevenueIntelligenceTenant:
 
     def policy(self) -> dict[str, str]:
         return self.bandit.policy()
+
+
+# ──────────────────────────── population governance (arm G) ────────────────────────────
+#
+# A GTM regression is often invisible per call — each enrichment looks reasonable — but obvious across
+# accounts: the planner suddenly escalates everyone to the expensive fallback, or collapses onto a single
+# provider, or average spend creeps up. These are population/cross-series rules ("≥K in a window", with
+# distinct-value counting), the same shape as the v0.3.0 governance PopulationRule, evaluated over the
+# tenant's per-account events. OBSERVE emits findings without changing execution; ENFORCE would gate.
+
+
+@dataclass(frozen=True)
+class PopulationRule:
+    """A "≥K within the last ``window`` events" rate rule over enrichment traces."""
+    name: str
+    kind: str                    # "provider_storm" | "source_monoculture" | "cost_runaway"
+    threshold: float             # count K (storm) | share in [0,1] (monoculture) | $/acct (runaway)
+    window: int = 50
+    provider: str = ""           # provider watched by storm/monoculture
+    disposition: str = "REQUIRE_REVIEW"
+
+
+@dataclass
+class Finding:
+    rule: str
+    disposition: str
+    detail: str
+    measured: float
+
+
+DEFAULT_POPULATION_RULES: tuple[PopulationRule, ...] = (
+    PopulationRule("expensive-provider storm", "provider_storm", threshold=5, window=40,
+                   provider="web_research"),
+    PopulationRule("source monoculture", "source_monoculture", threshold=0.8, window=40, provider="apollo"),
+    PopulationRule("cost runaway", "cost_runaway", threshold=0.12, window=40),
+)
+
+
+class GtmPopulationGovernor:
+    """Evaluates population rules over a stream of enrichment events. ``mode`` is OBSERVE (findings only)
+    or ENFORCE (findings that a caller would act on) — detection is identical either way, which is the
+    OBSERVE→ENFORCE equivalence the rollout depends on."""
+
+    def __init__(self, rules: tuple[PopulationRule, ...] = DEFAULT_POPULATION_RULES, mode: str = "OBSERVE"):
+        self.rules = rules
+        self.mode = mode
+
+    def evaluate(self, events: list[dict]) -> list[Finding]:
+        out: list[Finding] = []
+        for r in self.rules:
+            recent = events[-r.window:]
+            if not recent:
+                continue
+            if r.kind == "provider_storm":
+                # DISTINCT accounts that escalated to the watched provider (distinct_on=account_id)
+                accts = {e["account_id"] for e in recent if r.provider in e["providers"]}
+                if len(accts) >= r.threshold:
+                    out.append(Finding(r.name, r.disposition,
+                                       f"{len(accts)} accounts escalated to {r.provider} in {len(recent)} events",
+                                       float(len(accts))))
+            elif r.kind == "source_monoculture":
+                paid = [p for e in recent for p in e["providers"] if PROVIDER_COST[p] > 0]
+                share = (sum(1 for p in paid if p == r.provider) / len(paid)) if paid else 0.0
+                if share >= r.threshold:
+                    out.append(Finding(r.name, r.disposition,
+                                       f"{share:.0%} of paid calls went to {r.provider}", round(share, 3)))
+            elif r.kind == "cost_runaway":
+                avg = sum(e["cost"] for e in recent) / len(recent)
+                if avg >= r.threshold:
+                    out.append(Finding(r.name, r.disposition,
+                                       f"avg spend ${avg:.3f}/acct over {len(recent)} events "
+                                       f"exceeds ${r.threshold:.3f}", round(avg, 4)))
+        return out

--- a/context_runtime/integrations/revenue_intelligence.py
+++ b/context_runtime/integrations/revenue_intelligence.py
@@ -253,13 +253,21 @@ class RevenueIntelligenceTenant:
     @staticmethod
     def _default_registry(fixtures, approver, crm_tool=None) -> ToolRegistry:
         reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=approver))
-        # Live CRM is explicit opt-in (CR_CRM_LIVE=1 + a HubSpot key), so a key in the environment never
-        # silently makes the reproducible offline benchmark hit the network. Or pass crm_tool= directly.
+        # Live CRM is explicit opt-in (CR_CRM_LIVE=1 + a backend's credentials), so credentials sitting in
+        # the environment never silently make the reproducible offline benchmark hit the network. Pick the
+        # backend with CR_CRM_BACKEND=hubspot|salesforce, else auto-detect from which creds are present.
+        # Or pass crm_tool= directly.
         if crm_tool is None and os.getenv("CR_CRM_LIVE", "").strip().lower() in ("1", "true", "yes", "on"):
+            backend = os.getenv("CR_CRM_BACKEND", "").strip().lower()
             try:
-                from .hubspot_crm import HubSpotCRMTool, token_present
-                if token_present():
+                from .hubspot_crm import HubSpotCRMTool, token_present as _hs_present
+                from .salesforce_crm import SalesforceCRMTool, token_present as _sf_present
+                if backend == "salesforce" or (backend == "" and _sf_present() and not _hs_present()):
+                    crm_tool = SalesforceCRMTool(fixtures) if _sf_present() else None
+                elif _hs_present():
                     crm_tool = HubSpotCRMTool(fixtures)
+                elif _sf_present():
+                    crm_tool = SalesforceCRMTool(fixtures)
             except Exception:
                 crm_tool = None
         for name in ("crm", "sec", "apollo", "pdl", "hunter", "builtwith", "crunchbase", "web_research"):

--- a/context_runtime/integrations/revenue_intelligence.py
+++ b/context_runtime/integrations/revenue_intelligence.py
@@ -232,7 +232,7 @@ class RevenueIntelligenceTenant:
 
     def __init__(self, fixtures: dict[str, Fixture], *, runtime: ContextRuntime | None = None,
                  registry: ToolRegistry | None = None, bandit: EpsilonGreedyBandit | None = None,
-                 approver=None, no_outreach: bool = True, segmented: bool = False):
+                 approver=None, no_outreach: bool = True, segmented: bool = False, crm_tool=None):
         self.fixtures = fixtures
         self.runtime = runtime or ContextRuntime.default([])
         self.bandit = bandit or _gtm_bandit()
@@ -240,7 +240,9 @@ class RevenueIntelligenceTenant:
         # arm E keys the policy on the need alone; arm F on need×segment — the learned, empirical policy that
         # discovers a provider is authoritative for enterprise but not SMB, public but not private, etc.
         self.segmented = segmented
-        self.registry = registry or self._default_registry(fixtures, approver)
+        # ``crm_tool`` (e.g. HubSpotCRMTool) makes the ``crm`` provider a LIVE backend; None keeps the offline
+        # fixture. Auto-enabled when a HubSpot Service Key is in the environment.
+        self.registry = registry or self._default_registry(fixtures, approver, crm_tool)
         self.external_spend = 0.0
         self.events: list[dict] = []   # per-enrichment trace, for the population governor (arm G)
         self._pending: dict[str, tuple[Plan, ProviderBundle, str]] = {}
@@ -249,10 +251,22 @@ class RevenueIntelligenceTenant:
         return f"{bucket}|{fx.segment}" if self.segmented else bucket
 
     @staticmethod
-    def _default_registry(fixtures, approver) -> ToolRegistry:
+    def _default_registry(fixtures, approver, crm_tool=None) -> ToolRegistry:
         reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=approver))
+        # Live CRM is explicit opt-in (CR_CRM_LIVE=1 + a HubSpot key), so a key in the environment never
+        # silently makes the reproducible offline benchmark hit the network. Or pass crm_tool= directly.
+        if crm_tool is None and os.getenv("CR_CRM_LIVE", "").strip().lower() in ("1", "true", "yes", "on"):
+            try:
+                from .hubspot_crm import HubSpotCRMTool, token_present
+                if token_present():
+                    crm_tool = HubSpotCRMTool(fixtures)
+            except Exception:
+                crm_tool = None
         for name in ("crm", "sec", "apollo", "pdl", "hunter", "builtwith", "crunchbase", "web_research"):
-            reg.register(ProviderTool(name, fixtures))
+            if name == "crm" and crm_tool is not None:
+                reg.register(crm_tool)                       # live HubSpot backend for the crm capability
+            else:
+                reg.register(ProviderTool(name, fixtures))
         reg.register(PrepareOutreachTool())
         reg.register(SendOutreachTool())
         return reg

--- a/context_runtime/integrations/salesforce_crm.py
+++ b/context_runtime/integrations/salesforce_crm.py
@@ -1,0 +1,191 @@
+"""Salesforce CRM connector (Phase 5) — a second live backend for the ``crm`` capability.
+
+Reads Accounts over the Salesforce REST/SOQL API and, behind the approval gate, updates one. Authenticated
+by the **OAuth 2.0 Client Credentials flow** (server-to-server, no user password): a Connected/External
+Client App's consumer key + secret exchange for a short-lived bearer token, which is then sent on every API
+call. Credentials come from ``SALESFORCE_CONSUMER_KEY`` / ``SALESFORCE_CONSUMER_SECRET`` (or the
+``…_CLIENT_ID`` / ``…_CLIENT_SECRET`` aliases) and ``SALESFORCE_INSTANCE_URL`` — read from the environment,
+never logged. With any missing the connector reports itself unavailable and the tenant falls back to the
+offline fixture, so nothing here is required for the base benchmark.
+
+Mirrors the HubSpot connector's shape (search/get/create/update + an approval-gated write + seed), so the
+Revenue & Intelligence tenant treats the two design-partner CRMs interchangeably. Dependency-free (stdlib).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from ..tools.base import ToolResult, ToolSpec
+from ..types import Hit
+
+_API_VERSION = os.getenv("SALESFORCE_API_VERSION", "v60.0")
+_ACCOUNT_FIELDS = ["Id", "Name", "Website", "Industry", "NumberOfEmployees", "BillingCity", "BillingCountry"]
+
+
+class SalesforceError(RuntimeError):
+    pass
+
+
+def _creds() -> tuple[str, str, str]:
+    cid = os.getenv("SALESFORCE_CONSUMER_KEY") or os.getenv("SALESFORCE_CLIENT_ID") or ""
+    secret = os.getenv("SALESFORCE_CONSUMER_SECRET") or os.getenv("SALESFORCE_CLIENT_SECRET") or ""
+    instance = (os.getenv("SALESFORCE_INSTANCE_URL") or "").rstrip("/")
+    return cid, secret, instance
+
+
+def token_present() -> bool:
+    cid, secret, instance = _creds()
+    return bool(cid and secret and instance)
+
+
+class SalesforceCRM:
+    """Thin client over the Salesforce Account API. Fetches a client-credentials token on first use and
+    reuses it (re-fetching on a 401)."""
+
+    def __init__(self):
+        self._token: str | None = None
+        self._instance = _creds()[2]
+
+    # ── auth ──
+    def _fetch_token(self) -> None:
+        cid, secret, instance = _creds()
+        if not (cid and secret and instance):
+            raise SalesforceError("missing SALESFORCE_CONSUMER_KEY/SECRET or SALESFORCE_INSTANCE_URL")
+        body = urllib.parse.urlencode({
+            "grant_type": "client_credentials", "client_id": cid, "client_secret": secret}).encode()
+        req = urllib.request.Request(f"{instance}/services/oauth2/token", data=body, method="POST")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                data = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            raise SalesforceError(f"token request → {e.code}: {e.read().decode()[:300]}") from None
+        except urllib.error.URLError as e:
+            raise SalesforceError(f"token endpoint unreachable: {e.reason}") from None
+        self._token = data["access_token"]
+        self._instance = data.get("instance_url", self._instance).rstrip("/")
+
+    def _request(self, method: str, path: str, body: dict | None = None, *, _retry: bool = True) -> dict:
+        if self._token is None:
+            self._fetch_token()
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(f"{self._instance}{path}", data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            if e.code == 401 and _retry:                     # token expired → refresh once
+                self._token = None
+                return self._request(method, path, body, _retry=False)
+            raise SalesforceError(f"Salesforce {method} {path} → {e.code}: {e.read().decode()[:300]}") from None
+        except urllib.error.URLError as e:
+            raise SalesforceError(f"Salesforce {method} {path} unreachable: {e.reason}") from None
+
+    # ── accounts ──
+    def query(self, soql: str) -> list[dict]:
+        path = f"/services/data/{_API_VERSION}/query?q={urllib.parse.quote(soql)}"
+        return self._request("GET", path).get("records", [])
+
+    def search_account(self, *, domain: str | None = None, name: str | None = None) -> dict | None:
+        fields = ", ".join(_ACCOUNT_FIELDS)
+        if domain:
+            where = f"Website LIKE '%{domain}%'"
+        elif name:
+            where = f"Name = '{name}'"
+        else:
+            return None
+        rows = self.query(f"SELECT {fields} FROM Account WHERE {where} LIMIT 1")
+        return rows[0] if rows else None
+
+    def get_account(self, account_id: str) -> dict:
+        return self._request("GET", f"/services/data/{_API_VERSION}/sobjects/Account/{account_id}")
+
+    def create_account(self, fields: dict) -> str:
+        res = self._request("POST", f"/services/data/{_API_VERSION}/sobjects/Account", fields)
+        return res.get("id", "")
+
+    def update_account(self, account_id: str, fields: dict) -> dict:
+        # Salesforce PATCH returns 204 No Content on success
+        self._request("PATCH", f"/services/data/{_API_VERSION}/sobjects/Account/{account_id}", fields)
+        return {"id": account_id, "updated": True}
+
+    def upsert_account(self, fields: dict) -> str:
+        existing = self.search_account(domain=fields.get("Website"))
+        if existing:
+            return existing["Id"]
+        return self.create_account(fields)
+
+
+class SalesforceCRMTool:
+    """The ``crm`` provider backed by Salesforce. Registers under ``crm_enrich`` so it swaps in for the
+    offline fixture, resolving an account by domain and returning the CRM-known evidence."""
+
+    name = "crm"
+
+    def __init__(self, fixtures: dict | None = None, client: SalesforceCRM | None = None):
+        self._fx = fixtures or {}
+        self._client = client or SalesforceCRM()
+        self.live = token_present()
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name="crm_enrich", description="Resolve an account against Salesforce (read-only).",
+                        parameters={"type": "object", "properties": {
+                            "account_id": {"type": "string"}, "need": {"type": "string"}}})
+
+    def run(self, args: dict) -> ToolResult:
+        fx = self._fx.get(args.get("account_id", ""))
+        domain = getattr(fx, "domain", None) or args.get("domain")
+        if not (self.live and domain):
+            return ToolResult(ok=True, hits=[], data={"status": "missing", "live": self.live}, text="no CRM record")
+        try:
+            acct = self._client.search_account(domain=domain)
+        except SalesforceError:
+            return ToolResult(ok=True, hits=[], data={"status": "missing", "error": "crm unreachable"}, text="crm error")
+        if not acct:
+            return ToolResult(ok=True, hits=[], data={"status": "missing"}, text="not in CRM")
+        value = acct.get("Name") or domain
+        hit = Hit(chunk_id=f"salesforce::{acct['Id']}", filename="salesforce", source="crm",
+                  text=f"crm: {value} ({domain})", score=0.95)
+        return ToolResult(ok=True, hits=[hit], data={"status": "correct", "account_id": acct["Id"],
+                          "record": acct, "cost": 0.0}, text=hit.text)
+
+
+class SalesforceUpdateTool:
+    """Governed write-back: update an Account field. SIDE-EFFECTING + APPROVAL-REQUIRED."""
+
+    def __init__(self, client: SalesforceCRM | None = None):
+        self._client = client or SalesforceCRM()
+
+    def spec(self) -> ToolSpec:
+        return ToolSpec(name="crm_update", description="Update a Salesforce Account field.",
+                        parameters={"type": "object", "properties": {
+                            "account_id": {"type": "string"}, "fields": {"type": "object"}}},
+                        side_effecting=True, approval_required=True)
+
+    def run(self, args: dict) -> ToolResult:
+        try:
+            self._client.update_account(args["account_id"], args.get("fields", {}))
+        except SalesforceError as e:
+            return ToolResult(ok=False, data={"error": str(e)}, text=f"update failed: {e}")
+        return ToolResult(ok=True, data={"updated": args["account_id"]}, text=f"updated account {args['account_id']}")
+
+
+def seed_from_fixture(fixtures: dict, client: SalesforceCRM | None = None) -> dict[str, str]:
+    """Idempotently create the benchmark companies as Salesforce Accounts. Returns {account_id: sf_id}."""
+    client = client or SalesforceCRM()
+    out: dict[str, str] = {}
+    for aid, fx in fixtures.items():
+        fields = {"Name": fx.company, "Website": fx.domain}
+        if fx.need == "firmographics":
+            n = "".join(ch for ch in fx.truth if ch.isdigit())
+            if n:
+                fields["NumberOfEmployees"] = int(n)
+        out[aid] = client.upsert_account(fields)
+    return out

--- a/examples/hubspot_crm_smoke.py
+++ b/examples/hubspot_crm_smoke.py
@@ -1,0 +1,52 @@
+"""HubSpot CRM connector — live smoke (Phase 5). Run on the host that has the Service Key:
+
+    HUBSPOT_SERVICE_KEY=... python examples/hubspot_crm_smoke.py     # (key from ~/.bashrc on evo-x2)
+
+Seeds a few benchmark companies into your HubSpot account, resolves one, reads it back, and performs an
+approval-gated property update — proving the connector's reads + governed write end to end. Idempotent:
+re-running upserts by domain rather than duplicating. The token is read from the environment, never printed.
+"""
+from __future__ import annotations
+
+from context_runtime.integrations.hubspot_crm import (
+    HubSpotCRM, HubSpotCRMTool, HubSpotUpdateTool, seed_from_fixture, token_present,
+)
+from context_runtime.tools.base import ApprovalPolicy, ToolRegistry
+from examples.revenue_intelligence import FIXTURES
+
+
+def run() -> None:
+    if not token_present():
+        print("No HUBSPOT_SERVICE_KEY (or HUBSPOT_API_KEY) in the environment.")
+        print("Create a HubSpot Service Key (Development → Keys → Service Keys) with scopes")
+        print("crm.objects.{contacts,companies,deals}.read+write, then export HUBSPOT_SERVICE_KEY and re-run.")
+        return
+
+    client = HubSpotCRM()
+    seed = {k: FIXTURES[k] for k in list(FIXTURES)[:3]}       # a few companies is enough for a smoke
+    print(f"Seeding {len(seed)} companies into HubSpot (idempotent upsert by domain)…")
+    ids = seed_from_fixture(seed, client)
+    for aid, cid in ids.items():
+        print(f"  {aid}  {seed[aid].company:<22} {seed[aid].domain:<20} → company {cid}")
+
+    # resolve one via the tool the tenant uses (crm_enrich)
+    aid = next(iter(seed))
+    tool = HubSpotCRMTool(seed, client)
+    res = tool.run({"account_id": aid, "need": seed[aid].need})
+    print(f"\nresolve {aid} via crm_enrich → status={res.data.get('status')}: {res.text}")
+
+    # read back the raw record
+    cid = ids[aid]
+    company = client.get_company(cid)
+    print(f"read company {cid}: {company.get('properties', {})}")
+
+    # governed write: update a property, through the approval gate (approver says yes here)
+    reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=lambda spec: True))
+    reg.register(HubSpotUpdateTool(client))
+    upd = reg.run("crm_update", {"company_id": cid, "properties": {"industry": "SOFTWARE_DATA_INTERNET"}})
+    print(f"\ngoverned crm_update → ok={upd.ok}: {upd.text}")
+    print(f"audit: {reg.audit[-1]}")
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/hubspot_crm_smoke.py
+++ b/examples/hubspot_crm_smoke.py
@@ -29,21 +29,30 @@ def run() -> None:
     for aid, cid in ids.items():
         print(f"  {aid}  {seed[aid].company:<22} {seed[aid].domain:<20} → company {cid}")
 
-    # resolve one via the tool the tenant uses (crm_enrich)
+    # resolve one via the tool the tenant uses (crm_enrich). HubSpot's search index is eventually
+    # consistent, so a just-seeded record can take a few seconds to appear — retry briefly. (Real
+    # accounts are already indexed; this lag only affects freshly-created ones.)
+    import time
     aid = next(iter(seed))
     tool = HubSpotCRMTool(seed, client)
-    res = tool.run({"account_id": aid, "need": seed[aid].need})
-    print(f"\nresolve {aid} via crm_enrich → status={res.data.get('status')}: {res.text}")
+    for attempt in range(6):
+        res = tool.run({"account_id": aid, "need": seed[aid].need})
+        if res.data.get("status") == "correct":
+            break
+        time.sleep(3)
+    print(f"\nresolve {aid} via crm_enrich → status={res.data.get('status')} "
+          f"(after {attempt + 1} tries): {res.text}")
 
     # read back the raw record
     cid = ids[aid]
     company = client.get_company(cid)
     print(f"read company {cid}: {company.get('properties', {})}")
 
-    # governed write: update a property, through the approval gate (approver says yes here)
+    # governed write: update a property, through the approval gate (approver says yes here).
+    # industry is a HubSpot picklist — use a valid option.
     reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=lambda spec: True))
     reg.register(HubSpotUpdateTool(client))
-    upd = reg.run("crm_update", {"company_id": cid, "properties": {"industry": "SOFTWARE_DATA_INTERNET"}})
+    upd = reg.run("crm_update", {"company_id": cid, "properties": {"industry": "COMPUTER_SOFTWARE"}})
     print(f"\ngoverned crm_update → ok={upd.ok}: {upd.text}")
     print(f"audit: {reg.audit[-1]}")
 

--- a/examples/revenue_intelligence.py
+++ b/examples/revenue_intelligence.py
@@ -1,121 +1,145 @@
 """Revenue & Intelligence × Context Runtime — the GTM benchmark, offline.
 
 The canonical mission: *find the accounts most likely to need us, enrich the right buyer at each, don't
-overpay for data, and contact no one.* This runs it with no API keys over a labelled fixture and compares
-four ways to choose providers:
+overpay for data, and contact no one.* Runs with no API keys over a labelled fixture and compares how
+providers are chosen:
 
-    A  all providers        — call everything for every record (coverage ceiling, max cost)
-    B  fixed pipeline       — one hand-engineered provider set for every record (misses some needs)
-    C  cheapest-first       — always the free local source (cheap, usually insufficient)
-    E  ReDevOps adaptive    — the runtime learns the cheapest provider bundle sufficient for each need
+    A  all providers      — call everything for every record (coverage ceiling, max cost)
+    B  fixed pipeline     — one hand-engineered provider set for every record (misses some needs)
+    C  cheapest-first     — always the free local source (cheap, usually insufficient)
+    E  adaptive (need)    — learn the cheapest bundle sufficient for each need
+    F  learned (need×seg) — condition on segment too: a provider authoritative for enterprise but not SMB,
+                            public but not private — the empirical policy the static one can't express
+    G  + governance       — arm F with population/cross-series rules watching the account stream
 
-First publishable question (plan §17): can the runtime preserve enrichment quality while making materially
-fewer / cheaper paid provider calls than a fixed pipeline? And it keeps outreach behind a NO_OUTREACH gate.
+First publishable question (§17): preserve quality at fewer/cheaper paid calls than a fixed pipeline.
+Second (§18): can governance catch a cross-account regression invisible per call? Both, offline.
 
     python examples/revenue_intelligence.py
 """
 from __future__ import annotations
 
 from context_runtime.integrations.revenue_intelligence import (
-    DEFAULT_BUNDLES, Fixture, ProviderBundle, RevenueIntelligenceTenant, _gtm_bandit,
-    outcome_for, reward_enrich,
+    DEFAULT_BUNDLES, DEFAULT_POPULATION_RULES, Fixture, GtmPopulationGovernor, ProviderBundle,
+    RevenueIntelligenceTenant, _gtm_bandit, outcome_for,
 )
 
-# ── labelled fixture: real GTM shape — each account has a decisive provider for its need, and two carry a
-#    confident wrong-entity trap (a provider that returns the wrong company). Tier-2 disclosed labels. ──
+# ── labelled fixture with a SEGMENT axis: several needs have a segment-dependent decisive provider
+#    (apollo authoritative for enterprise people, pdl for SMB; apollo for enterprise firmographics,
+#    crunchbase for SMB; SEC for public-company funding, crunchbase for private). Two wrong-entity traps. ──
 FIXTURES: dict[str, Fixture] = {f.account_id: f for f in [
-    Fixture("a01", "Northwind Health", "northwind.io", "company_identity", "pdl", "Northwind Health Inc"),
-    Fixture("a02", "Contoso Robotics", "contoso.ai", "company_identity", "pdl", "Contoso Robotics",
-            wrong=("apollo",)),                                   # apollo confidently returns a wrong org
-    Fixture("a03", "Fabrikam Data", "fabrikam.com", "person_role", "apollo", "VP Data Platform"),
-    Fixture("a04", "Tailspin Analytics", "tailspin.co", "person_role", "apollo", "Head of ML"),
-    Fixture("a05", "Proseware AI", "proseware.ai", "firmographics", "apollo", "Series B, 180 staff"),
-    Fixture("a06", "Wingtip Cloud", "wingtip.dev", "firmographics", "apollo", "Series A, 60 staff"),
-    Fixture("a07", "Adventure Works", "adventure.works", "contact_verify", "hunter", "cto@adventure.works"),
-    Fixture("a08", "Litware Systems", "litware.com", "contact_verify", "hunter", "vp.eng@litware.com",
-            wrong=("apollo",)),                                   # apollo returns a stale/guessed address
-    Fixture("a09", "Coho Vineyard", "coho.wine", "tech_signal", "builtwith", "Kubernetes + Snowflake"),
-    Fixture("a10", "Fourth Coffee", "fourthcoffee.io", "tech_signal", "builtwith", "Databricks + Kafka"),
-    Fixture("a11", "Graphic Design Inst", "gdi.edu", "company_identity", "pdl", "Graphic Design Institute"),
-    Fixture("a12", "Humongous Insurance", "humongous.com", "person_role", "apollo", "Chief Data Officer"),
-    Fixture("a13", "Lucerne Publishing", "lucerne.press", "tech_signal", "builtwith", "AWS + dbt"),
-    Fixture("a14", "Margie's Travel", "margies.travel", "firmographics", "apollo", "Bootstrapped, 25 staff"),
-    Fixture("a15", "Blue Yonder Air", "blueyonder.aero", "contact_verify", "hunter", "head.data@blueyonder.aero"),
+    # company_identity — segment-independent (pdl)
+    Fixture("a01", "Northwind Health", "northwind.io", "company_identity", "pdl", "Northwind Health Inc", segment="enterprise"),
+    Fixture("a02", "Contoso Robotics", "contoso.ai", "company_identity", "pdl", "Contoso Robotics", wrong=("apollo",), segment="smb"),
+    # person_role — segment-DEPENDENT: enterprise→apollo, smb→pdl
+    Fixture("a03", "Fabrikam Data", "fabrikam.com", "person_role", "apollo", "VP Data Platform", segment="enterprise"),
+    Fixture("a04", "Tailspin Analytics", "tailspin.co", "person_role", "pdl", "Head of ML", segment="smb"),
+    Fixture("a05", "Humongous Insurance", "humongous.com", "person_role", "apollo", "Chief Data Officer", segment="enterprise"),
+    Fixture("a06", "Margie's Startup", "margies.dev", "person_role", "pdl", "Founding Engineer", segment="smb"),
+    # firmographics — segment-DEPENDENT: enterprise→apollo, smb→crunchbase
+    Fixture("a07", "Proseware AI", "proseware.ai", "firmographics", "apollo", "12,000 staff", segment="enterprise"),
+    Fixture("a08", "Wingtip Cloud", "wingtip.dev", "firmographics", "crunchbase", "Series A, 60 staff", segment="smb"),
+    # contact_verify — segment-independent (hunter); a08-style apollo trap
+    Fixture("a09", "Adventure Works", "adventure.works", "contact_verify", "hunter", "cto@adventure.works", segment="enterprise"),
+    Fixture("a10", "Litware Systems", "litware.com", "contact_verify", "hunter", "vp.eng@litware.com", wrong=("apollo",), segment="smb"),
+    # tech_signal — segment-independent (builtwith)
+    Fixture("a11", "Coho Vineyard", "coho.wine", "tech_signal", "builtwith", "Kubernetes + Snowflake", segment="smb"),
+    Fixture("a12", "Lucerne Publishing", "lucerne.press", "tech_signal", "builtwith", "AWS + dbt", segment="enterprise"),
+    # funding_signal — segment-DEPENDENT: public→sec (free!), private→crunchbase
+    Fixture("a13", "Fourth Coffee Corp", "fourthcoffee.com", "funding_signal", "sec", "10-K FY2025", segment="public"),
+    Fixture("a14", "Blue Yonder Air", "blueyonder.aero", "funding_signal", "crunchbase", "Series C, $80M", segment="private"),
+    # niche_signal — the expensive unstructured fallback (web_research)
+    Fixture("a15", "Graphic Design Inst", "gdi.edu", "niche_signal", "web_research", "mentioned on a forum", segment="default"),
 ]}
 
-FIXED_PIPELINE = ProviderBundle(("crm", "apollo", "pdl"))    # arm B: competent, but no hunter/builtwith
+FIXED_PIPELINE = ProviderBundle(("crm", "apollo", "pdl"))    # arm B
 CHEAPEST = ProviderBundle(("crm",))                          # arm C
 ALL = DEFAULT_BUNDLES[-1]                                    # arm A
 
 
-def _static_arm(bundle: ProviderBundle):
-    """Quality (correct rate), avg external cost, and paid-call count for a fixed-bundle arm."""
+def _static_arm(bundle: ProviderBundle) -> dict:
+    from context_runtime.integrations.revenue_intelligence import PROVIDER_COST
     correct = cost = calls = 0
     for fx in FIXTURES.values():
-        oc = outcome_for(bundle, fx)
-        correct += int(oc == "correct")
+        correct += int(outcome_for(bundle, fx) == "correct")
         cost += bundle.cost
-        calls += sum(1 for p in bundle.providers if p != "crm")   # crm/local is free, not a paid call
+        calls += sum(1 for p in bundle.providers if PROVIDER_COST[p] > 0)
     n = len(FIXTURES)
     return {"quality": correct / n, "cost_per_acct": cost / n, "paid_calls": calls}
 
 
-def run(rounds: int = 240) -> None:
-    tenant = RevenueIntelligenceTenant(FIXTURES, bandit=_gtm_bandit(0.1),
-                                       approver=lambda spec: False,  # no human here → send stays denied
-                                       no_outreach=True)
+def _train(segmented: bool, rounds: int = 400) -> RevenueIntelligenceTenant:
+    t = RevenueIntelligenceTenant(FIXTURES, bandit=_gtm_bandit(0.1),
+                                  approver=lambda spec: False, no_outreach=True, segmented=segmented)
     ids = list(FIXTURES)
-
-    # Arm E: learn per-need which cheapest bundle is sufficient.
     for i in range(rounds):
         aid = ids[i % len(ids)]
-        r = tenant.enrich(aid)
-        tenant.record_outcome(aid, r.outcome)
+        t.record_outcome(aid, t.enrich(aid).outcome)
+    return t
 
-    # steady-state pass over the learned policy (ε→0): use the current best bundle per need.
-    e_correct = e_cost = e_calls = 0
-    for aid, fx in FIXTURES.items():
-        best_key = tenant.policy()[fx.need]
-        bundle = next(b for b in DEFAULT_BUNDLES if b.key == best_key)
-        oc = outcome_for(bundle, fx)
-        e_correct += int(oc == "correct")
-        e_cost += bundle.cost
-        e_calls += sum(1 for p in bundle.providers if p != "crm")
+
+def _eval_policy(t: RevenueIntelligenceTenant) -> dict:
+    from context_runtime.integrations.revenue_intelligence import PROVIDER_COST
+    pol = t.policy()
+    correct = cost = calls = 0
+    for fx in FIXTURES.values():
+        key = t._ctx(fx, fx.need)
+        bundle = next(b for b in DEFAULT_BUNDLES if b.key == pol[key])
+        correct += int(outcome_for(bundle, fx) == "correct")
+        cost += bundle.cost
+        calls += sum(1 for p in bundle.providers if PROVIDER_COST[p] > 0)
     n = len(FIXTURES)
-    arm_e = {"quality": e_correct / n, "cost_per_acct": e_cost / n, "paid_calls": e_calls}
+    return {"quality": correct / n, "cost_per_acct": cost / n, "paid_calls": calls}
 
+
+def run() -> None:
+    tenant_e = _train(segmented=False)
+    tenant_f = _train(segmented=True)
     arms = {
-        "A  all providers":   _static_arm(ALL),
-        "B  fixed pipeline":  _static_arm(FIXED_PIPELINE),
-        "C  cheapest-first":  _static_arm(CHEAPEST),
-        "E  ReDevOps adaptive": arm_e,
+        "A  all providers":     _static_arm(ALL),
+        "B  fixed pipeline":    _static_arm(FIXED_PIPELINE),
+        "C  cheapest-first":    _static_arm(CHEAPEST),
+        "E  adaptive (need)":   _eval_policy(tenant_e),
+        "F  learned (need×seg)": _eval_policy(tenant_f),
     }
 
     print("Canonical mission: 15 candidate accounts · enrich the decisive need at each · contact no one\n")
-    print(f"  {'arm':<22}{'quality':>9}{'$ / acct':>11}{'paid calls':>12}")
+    print(f"  {'arm':<24}{'quality':>9}{'$ / acct':>11}{'paid calls':>12}")
     for name, m in arms.items():
-        print(f"  {name:<22}{m['quality']*100:>7.0f}% {m['cost_per_acct']:>10.3f} {m['paid_calls']:>11d}")
+        print(f"  {name:<24}{m['quality']*100:>7.0f}% {m['cost_per_acct']:>10.3f} {m['paid_calls']:>11d}")
 
-    b, e = arms["B  fixed pipeline"], arms["E  ReDevOps adaptive"]
-    dq = (e["quality"] - b["quality"]) * 100
-    dcost = (1 - e["cost_per_acct"] / b["cost_per_acct"]) * 100 if b["cost_per_acct"] else 0
-    dcalls = b["paid_calls"] - e["paid_calls"]
-    print(f"\n  ── adaptive (E) vs fixed pipeline (B) ──")
-    print(f"     quality:    {dq:+.0f} pts   ({e['quality']*100:.0f}% vs {b['quality']*100:.0f}%)")
-    print(f"     cost/acct:  {dcost:+.0f}%    (${e['cost_per_acct']:.3f} vs ${b['cost_per_acct']:.3f})")
-    print(f"     paid calls: {dcalls:+d}     ({e['paid_calls']} vs {b['paid_calls']})")
+    b, e, f = arms["B  fixed pipeline"], arms["E  adaptive (need)"], arms["F  learned (need×seg)"]
+    print(f"\n  ── adaptive E vs fixed pipeline B ──  quality {(e['quality']-b['quality'])*100:+.0f} pts, "
+          f"cost {(1-e['cost_per_acct']/b['cost_per_acct'])*100:+.0f}%, calls {b['paid_calls']-e['paid_calls']:+d}")
+    print(f"  ── learned F vs adaptive E    ──  quality {(f['quality']-e['quality'])*100:+.0f} pts, "
+          f"cost {(1-f['cost_per_acct']/e['cost_per_acct'])*100:+.0f}% (${f['cost_per_acct']:.3f} vs ${e['cost_per_acct']:.3f}), "
+          f"same-or-fewer calls — segment conditioning pays for itself")
 
-    print("\n── learned provider policy per need ──")
-    for need in sorted({f.need for f in FIXTURES.values()}):
-        print(f"  {need:<18} → {tenant.policy()[need]}")
+    print("\n── learned provider policy (arm F, per need×segment) ──")
+    for key in sorted(tenant_f.policy()):
+        print(f"  {key:<26} → {tenant_f.policy()[key]}")
 
-    # governance: prepare is allowed, send is denied under NO_OUTREACH
-    prep = tenant.prepare_outreach("a03")
-    sent = tenant.send_outreach("a03")
-    print(f"\n── governance (NO_OUTREACH) ──")
-    print(f"  outreach_prepare → ok={prep.ok}: {prep.text}")
-    print(f"  outreach_send    → ok={sent.ok}: {sent.text}")
-    print(f"  audit: {tenant.registry.audit[-1]}")
+    # ── arm G: population governance over the account stream ──
+    healthy = GtmPopulationGovernor(mode="OBSERVE").evaluate(tenant_f.events)
+    # inject a controlled regression: a batch where every account escalates to the expensive fallback
+    # (a provider outage / prompt regression would look exactly like this — invisible per call)
+    regression = [{"account_id": f"r{i}", "need": "firmographics", "segment": "smb",
+                   "bundle": "apollo+web_research", "providers": ("apollo", "web_research"),
+                   "cost": 0.32, "outcome": "correct"} for i in range(8)]
+    observe = GtmPopulationGovernor(DEFAULT_POPULATION_RULES, mode="OBSERVE").evaluate(regression)
+    enforce = GtmPopulationGovernor(DEFAULT_POPULATION_RULES, mode="ENFORCE").evaluate(regression)
+
+    print(f"\n── governance (arm G) ──")
+    print(f"  healthy stream ({len(tenant_f.events)} events): {len(healthy)} findings")
+    print(f"  injected regression (8 accounts escalate to web_research):")
+    for fnd in observe:
+        print(f"    ⚠ {fnd.rule:<26} [{fnd.disposition}] {fnd.detail}")
+    same = [(f.rule, f.disposition) for f in observe] == [(f.rule, f.disposition) for f in enforce]
+    print(f"  OBSERVE→ENFORCE detection identical: {same}  (OBSERVE emits, ENFORCE would gate)")
+
+    # governance: prepare allowed, send denied under NO_OUTREACH
+    prep, sent = tenant_f.prepare_outreach("a03"), tenant_f.send_outreach("a03")
+    print(f"\n── NO_OUTREACH ──  prepare ok={prep.ok} · send ok={sent.ok} ({sent.text})")
 
 
 if __name__ == "__main__":

--- a/examples/revenue_intelligence.py
+++ b/examples/revenue_intelligence.py
@@ -1,0 +1,122 @@
+"""Revenue & Intelligence × Context Runtime — the GTM benchmark, offline.
+
+The canonical mission: *find the accounts most likely to need us, enrich the right buyer at each, don't
+overpay for data, and contact no one.* This runs it with no API keys over a labelled fixture and compares
+four ways to choose providers:
+
+    A  all providers        — call everything for every record (coverage ceiling, max cost)
+    B  fixed pipeline       — one hand-engineered provider set for every record (misses some needs)
+    C  cheapest-first       — always the free local source (cheap, usually insufficient)
+    E  ReDevOps adaptive    — the runtime learns the cheapest provider bundle sufficient for each need
+
+First publishable question (plan §17): can the runtime preserve enrichment quality while making materially
+fewer / cheaper paid provider calls than a fixed pipeline? And it keeps outreach behind a NO_OUTREACH gate.
+
+    python examples/revenue_intelligence.py
+"""
+from __future__ import annotations
+
+from context_runtime.integrations.revenue_intelligence import (
+    DEFAULT_BUNDLES, Fixture, ProviderBundle, RevenueIntelligenceTenant, _gtm_bandit,
+    outcome_for, reward_enrich,
+)
+
+# ── labelled fixture: real GTM shape — each account has a decisive provider for its need, and two carry a
+#    confident wrong-entity trap (a provider that returns the wrong company). Tier-2 disclosed labels. ──
+FIXTURES: dict[str, Fixture] = {f.account_id: f for f in [
+    Fixture("a01", "Northwind Health", "northwind.io", "company_identity", "pdl", "Northwind Health Inc"),
+    Fixture("a02", "Contoso Robotics", "contoso.ai", "company_identity", "pdl", "Contoso Robotics",
+            wrong=("apollo",)),                                   # apollo confidently returns a wrong org
+    Fixture("a03", "Fabrikam Data", "fabrikam.com", "person_role", "apollo", "VP Data Platform"),
+    Fixture("a04", "Tailspin Analytics", "tailspin.co", "person_role", "apollo", "Head of ML"),
+    Fixture("a05", "Proseware AI", "proseware.ai", "firmographics", "apollo", "Series B, 180 staff"),
+    Fixture("a06", "Wingtip Cloud", "wingtip.dev", "firmographics", "apollo", "Series A, 60 staff"),
+    Fixture("a07", "Adventure Works", "adventure.works", "contact_verify", "hunter", "cto@adventure.works"),
+    Fixture("a08", "Litware Systems", "litware.com", "contact_verify", "hunter", "vp.eng@litware.com",
+            wrong=("apollo",)),                                   # apollo returns a stale/guessed address
+    Fixture("a09", "Coho Vineyard", "coho.wine", "tech_signal", "builtwith", "Kubernetes + Snowflake"),
+    Fixture("a10", "Fourth Coffee", "fourthcoffee.io", "tech_signal", "builtwith", "Databricks + Kafka"),
+    Fixture("a11", "Graphic Design Inst", "gdi.edu", "company_identity", "pdl", "Graphic Design Institute"),
+    Fixture("a12", "Humongous Insurance", "humongous.com", "person_role", "apollo", "Chief Data Officer"),
+    Fixture("a13", "Lucerne Publishing", "lucerne.press", "tech_signal", "builtwith", "AWS + dbt"),
+    Fixture("a14", "Margie's Travel", "margies.travel", "firmographics", "apollo", "Bootstrapped, 25 staff"),
+    Fixture("a15", "Blue Yonder Air", "blueyonder.aero", "contact_verify", "hunter", "head.data@blueyonder.aero"),
+]}
+
+FIXED_PIPELINE = ProviderBundle(("crm", "apollo", "pdl"))    # arm B: competent, but no hunter/builtwith
+CHEAPEST = ProviderBundle(("crm",))                          # arm C
+ALL = DEFAULT_BUNDLES[-1]                                    # arm A
+
+
+def _static_arm(bundle: ProviderBundle):
+    """Quality (correct rate), avg external cost, and paid-call count for a fixed-bundle arm."""
+    correct = cost = calls = 0
+    for fx in FIXTURES.values():
+        oc = outcome_for(bundle, fx)
+        correct += int(oc == "correct")
+        cost += bundle.cost
+        calls += sum(1 for p in bundle.providers if p != "crm")   # crm/local is free, not a paid call
+    n = len(FIXTURES)
+    return {"quality": correct / n, "cost_per_acct": cost / n, "paid_calls": calls}
+
+
+def run(rounds: int = 240) -> None:
+    tenant = RevenueIntelligenceTenant(FIXTURES, bandit=_gtm_bandit(0.1),
+                                       approver=lambda spec: False,  # no human here → send stays denied
+                                       no_outreach=True)
+    ids = list(FIXTURES)
+
+    # Arm E: learn per-need which cheapest bundle is sufficient.
+    for i in range(rounds):
+        aid = ids[i % len(ids)]
+        r = tenant.enrich(aid)
+        tenant.record_outcome(aid, r.outcome)
+
+    # steady-state pass over the learned policy (ε→0): use the current best bundle per need.
+    e_correct = e_cost = e_calls = 0
+    for aid, fx in FIXTURES.items():
+        best_key = tenant.policy()[fx.need]
+        bundle = next(b for b in DEFAULT_BUNDLES if b.key == best_key)
+        oc = outcome_for(bundle, fx)
+        e_correct += int(oc == "correct")
+        e_cost += bundle.cost
+        e_calls += sum(1 for p in bundle.providers if p != "crm")
+    n = len(FIXTURES)
+    arm_e = {"quality": e_correct / n, "cost_per_acct": e_cost / n, "paid_calls": e_calls}
+
+    arms = {
+        "A  all providers":   _static_arm(ALL),
+        "B  fixed pipeline":  _static_arm(FIXED_PIPELINE),
+        "C  cheapest-first":  _static_arm(CHEAPEST),
+        "E  ReDevOps adaptive": arm_e,
+    }
+
+    print("Canonical mission: 15 candidate accounts · enrich the decisive need at each · contact no one\n")
+    print(f"  {'arm':<22}{'quality':>9}{'$ / acct':>11}{'paid calls':>12}")
+    for name, m in arms.items():
+        print(f"  {name:<22}{m['quality']*100:>7.0f}% {m['cost_per_acct']:>10.3f} {m['paid_calls']:>11d}")
+
+    b, e = arms["B  fixed pipeline"], arms["E  ReDevOps adaptive"]
+    dq = (e["quality"] - b["quality"]) * 100
+    dcost = (1 - e["cost_per_acct"] / b["cost_per_acct"]) * 100 if b["cost_per_acct"] else 0
+    dcalls = b["paid_calls"] - e["paid_calls"]
+    print(f"\n  ── adaptive (E) vs fixed pipeline (B) ──")
+    print(f"     quality:    {dq:+.0f} pts   ({e['quality']*100:.0f}% vs {b['quality']*100:.0f}%)")
+    print(f"     cost/acct:  {dcost:+.0f}%    (${e['cost_per_acct']:.3f} vs ${b['cost_per_acct']:.3f})")
+    print(f"     paid calls: {dcalls:+d}     ({e['paid_calls']} vs {b['paid_calls']})")
+
+    print("\n── learned provider policy per need ──")
+    for need in sorted({f.need for f in FIXTURES.values()}):
+        print(f"  {need:<18} → {tenant.policy()[need]}")
+
+    # governance: prepare is allowed, send is denied under NO_OUTREACH
+    prep = tenant.prepare_outreach("a03")
+    sent = tenant.send_outreach("a03")
+    print(f"\n── governance (NO_OUTREACH) ──")
+    print(f"  outreach_prepare → ok={prep.ok}: {prep.text}")
+    print(f"  outreach_send    → ok={sent.ok}: {sent.text}")
+    print(f"  audit: {tenant.registry.audit[-1]}")
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/revenue_intelligence_live_mission.py
+++ b/examples/revenue_intelligence_live_mission.py
@@ -1,0 +1,100 @@
+"""Revenue & Intelligence — the full canonical mission, live.
+
+Runs the mission end to end against a REAL CRM (Salesforce or HubSpot): for each account the runtime tries
+the live CRM first (free first hop), enriches only what the CRM is missing via the learned adaptive policy
+(need×segment), keeps external spend under budget, evaluates the population governor over the run, and
+contacts no one. This is the plan's §2 mission with a real design-partner CRM in the loop.
+
+    CR_CRM_BACKEND=salesforce python examples/revenue_intelligence_live_mission.py   # or hubspot
+
+Credentials come from the environment (the connectors read them; never printed). The 3 companies seeded by
+the CRM smokes resolve for free; the rest are enriched by the cheapest sufficient provider per need.
+"""
+from __future__ import annotations
+
+import os
+
+from context_runtime.integrations.revenue_intelligence import (
+    DEFAULT_BUNDLES, GtmPopulationGovernor, RevenueIntelligenceTenant, _gtm_bandit, outcome_for,
+)
+from context_runtime.integrations.hubspot_crm import HubSpotCRMTool, token_present as hs_present
+from context_runtime.integrations.salesforce_crm import SalesforceCRMTool, token_present as sf_present
+from examples.revenue_intelligence import FIXTURES
+
+BUDGET = 5.00
+
+
+def _pick_crm():
+    want = os.getenv("CR_CRM_BACKEND", "").strip().lower()
+    if want == "hubspot" and hs_present():
+        return HubSpotCRMTool(FIXTURES), "HubSpot"
+    if want == "salesforce" and sf_present():
+        return SalesforceCRMTool(FIXTURES), "Salesforce"
+    if sf_present():
+        return SalesforceCRMTool(FIXTURES), "Salesforce"
+    if hs_present():
+        return HubSpotCRMTool(FIXTURES), "HubSpot"
+    return None, None
+
+
+def _learned_tenant() -> RevenueIntelligenceTenant:
+    """Train arm F offline to get the cheapest sufficient provider per need×segment (the policy the mission
+    uses to escalate) and to host the approval-gated outreach gate."""
+    t = RevenueIntelligenceTenant(FIXTURES, bandit=_gtm_bandit(0.1), approver=lambda spec: False,
+                                  segmented=True, no_outreach=True)
+    ids = list(FIXTURES)
+    for i in range(400):
+        t.record_outcome(ids[i % len(ids)], t.enrich(ids[i % len(ids)]).outcome)
+    return t
+
+
+def run() -> None:
+    crm, backend = _pick_crm()
+    if crm is None:
+        print("No live CRM credentials in the environment (HubSpot or Salesforce). Aborting.")
+        return
+    print(f"MISSION  find/enrich the decisive buyer per account  ·  CRM={backend}  ·  "
+          f"budget ${BUDGET:.2f}  ·  NO_OUTREACH\n")
+
+    trained = _learned_tenant()
+    policy = trained.policy()
+    events: list[dict] = []
+    spend, correct, resolved_local, paid = 0.0, 0, 0, 0
+
+    for aid, fx in FIXTURES.items():
+        crm_res = crm.run({"account_id": aid, "need": fx.need})       # free first hop — the real CRM
+        if crm_res.data.get("status") == "correct":
+            resolved_local += 1
+            correct += 1
+            events.append({"account_id": aid, "need": fx.need, "segment": fx.segment,
+                           "bundle": "crm", "providers": ("crm",), "cost": 0.0, "outcome": "correct"})
+            print(f"  ✓ {fx.company:<22}{fx.need:<16} resolved from {backend} CRM  ($0.00)")
+            continue
+        # escalate: the learned cheapest provider bundle for this need×segment
+        bundle = next(b for b in DEFAULT_BUNDLES if b.key == policy[f"{fx.need}|{fx.segment}"])
+        oc = outcome_for(bundle, fx)
+        spend += bundle.cost
+        paid += 1
+        correct += int(oc == "correct")
+        events.append({"account_id": aid, "need": fx.need, "segment": fx.segment, "bundle": bundle.key,
+                       "providers": bundle.providers, "cost": bundle.cost, "outcome": oc})
+        print(f"  → {fx.company:<22}{fx.need:<16} enrich via {bundle.key:<12} (${bundle.cost:.2f})  [{oc}]")
+
+    findings = GtmPopulationGovernor(mode="OBSERVE").evaluate(events)
+    prep = trained.prepare_outreach(next(iter(FIXTURES)))
+    sent = trained.send_outreach(next(iter(FIXTURES)))
+    n = len(FIXTURES)
+
+    print("\n── EXPLAIN ──")
+    print(f"  {n} accounts evaluated")
+    print(f"  {resolved_local} resolved from the CRM at $0 (paid calls avoided)")
+    print(f"  {paid} external enrichments · quality {correct}/{n} correct")
+    print(f"  external-data spend: ${spend:.2f} / ${BUDGET:.2f} budget  ({spend/BUDGET*100:.0f}% used)")
+    print(f"  governance findings: {len(findings)} " + (f"({[f.rule for f in findings]})" if findings else "(healthy)"))
+    print(f"  outreach: prepare ok={prep.ok} · send ok={sent.ok} ({sent.text})")
+    print(f"\n  vs a fixed all-providers pass ({n} accts × every paid source): the runtime paid for "
+          f"{paid} of {n} accounts and skipped {resolved_local} entirely by checking the CRM first.")
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/salesforce_crm_smoke.py
+++ b/examples/salesforce_crm_smoke.py
@@ -1,0 +1,53 @@
+"""Salesforce CRM connector — live smoke (Phase 5). Run on the host with the credentials:
+
+    python examples/salesforce_crm_smoke.py     # reads SALESFORCE_CONSUMER_KEY/SECRET + _INSTANCE_URL
+
+Fetches a client-credentials token, seeds a few benchmark accounts, resolves one, reads it back, and
+performs an approval-gated field update — proving the connector's auth, reads + governed write end to end.
+Idempotent (upsert by Website). Credentials are read from the environment, never printed.
+"""
+from __future__ import annotations
+
+from context_runtime.integrations.salesforce_crm import (
+    SalesforceCRM, SalesforceCRMTool, SalesforceUpdateTool, seed_from_fixture, token_present,
+)
+from context_runtime.tools.base import ApprovalPolicy, ToolRegistry
+from examples.revenue_intelligence import FIXTURES
+
+
+def run() -> None:
+    if not token_present():
+        print("Missing Salesforce credentials in the environment. Set:")
+        print("  SALESFORCE_CONSUMER_KEY, SALESFORCE_CONSUMER_SECRET, SALESFORCE_INSTANCE_URL")
+        print("and enable the Client Credentials Flow (with a Run-As user) on the External Client App.")
+        return
+
+    client = SalesforceCRM()
+    print("Fetching client-credentials token…")
+    client._fetch_token()                                    # surfaces auth errors early (never prints token)
+    print("  token acquired; instance:", client._instance)
+
+    seed = {k: FIXTURES[k] for k in list(FIXTURES)[:3]}
+    print(f"\nSeeding {len(seed)} accounts (idempotent upsert by Website)…")
+    ids = seed_from_fixture(seed, client)
+    for aid, sid in ids.items():
+        print(f"  {aid}  {seed[aid].company:<22} {seed[aid].domain:<20} → account {sid}")
+
+    aid = next(iter(seed))
+    tool = SalesforceCRMTool(seed, client)
+    res = tool.run({"account_id": aid, "need": seed[aid].need})
+    print(f"\nresolve {aid} via crm_enrich → status={res.data.get('status')}: {res.text}")
+
+    acct = client.get_account(ids[aid])
+    print(f"read account {ids[aid]}: name={acct.get('Name')} website={acct.get('Website')} "
+          f"industry={acct.get('Industry')}")
+
+    reg = ToolRegistry(ApprovalPolicy(mode="deny_side_effects", approver=lambda spec: True))
+    reg.register(SalesforceUpdateTool(client))
+    upd = reg.run("crm_update", {"account_id": ids[aid], "fields": {"Industry": "Technology"}})
+    print(f"\ngoverned crm_update → ok={upd.ok}: {upd.text}")
+    print(f"audit: {reg.audit[-1]}")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_hubspot_crm.py
+++ b/tests/test_hubspot_crm.py
@@ -1,0 +1,95 @@
+"""HubSpot CRM connector — offline unit tests (no network, no key required).
+
+Verifies the graceful no-token fallback, the request construction (method/path/body + Bearer auth via a
+stubbed transport), and that the tenant transparently falls back to the offline fixture with no key. Live
+end-to-end is covered by examples/hubspot_crm_smoke.py, which needs a Service Key.
+"""
+from __future__ import annotations
+
+import pytest
+
+from context_runtime.integrations import hubspot_crm as hs
+from context_runtime.integrations.revenue_intelligence import Fixture, RevenueIntelligenceTenant
+
+
+def test_no_token_reports_unavailable(monkeypatch):
+    monkeypatch.delenv("HUBSPOT_SERVICE_KEY", raising=False)
+    monkeypatch.delenv("HUBSPOT_API_KEY", raising=False)
+    assert hs.token_present() is False
+    fx = {"a1": Fixture("a1", "Acme", "acme.io", "company_identity", "crm", "Acme")}
+    tool = hs.HubSpotCRMTool(fx)
+    res = tool.run({"account_id": "a1", "need": "company_identity"})
+    assert res.ok and res.data["status"] == "missing" and res.data["live"] is False
+
+
+def test_request_uses_bearer_and_correct_endpoints(monkeypatch):
+    calls = []
+
+    def fake_request(method, path, body=None, *, timeout=20.0):
+        calls.append((method, path, body))
+        if path.endswith("/search"):
+            return {"results": [{"id": "77", "properties": {"name": "Acme", "domain": "acme.io"}}]}
+        if method == "POST":
+            return {"id": "99"}
+        if method == "PATCH":
+            return {"id": path.rsplit("/", 1)[-1]}
+        return {"id": "77", "properties": {"name": "Acme"}}
+
+    monkeypatch.setattr(hs, "_request", fake_request)
+    client = hs.HubSpotCRM()
+
+    found = client.search_company(domain="acme.io")
+    assert found["id"] == "77"
+    assert calls[-1][0] == "POST" and calls[-1][1] == "/crm/v3/objects/companies/search"
+    assert calls[-1][2]["filterGroups"][0]["filters"][0] == {
+        "propertyName": "domain", "operator": "EQ", "value": "acme.io"}
+
+    new_id = client.create_company({"name": "Beta", "domain": "beta.io"})
+    assert new_id == "99" and calls[-1][:2] == ("POST", "/crm/v3/objects/companies")
+
+    client.update_company("77", {"industry": "SOFTWARE"})
+    assert calls[-1][0] == "PATCH" and calls[-1][1] == "/crm/v3/objects/companies/77"
+
+    # upsert is idempotent: domain already exists → returns its id, no create
+    n_before = len(calls)
+    assert client.upsert_company({"name": "Acme", "domain": "acme.io"}) == "77"
+    assert not any(c[0] == "POST" and c[1] == "/crm/v3/objects/companies" for c in calls[n_before:])
+
+
+def test_bearer_header_attached(monkeypatch):
+    """The token is sent as a Bearer header (checked via a stubbed urlopen — value never surfaced)."""
+    monkeypatch.setenv("HUBSPOT_SERVICE_KEY", "pat-na2-test-000")
+    seen = {}
+
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return b'{"results": []}'
+
+    def fake_urlopen(req, timeout=20.0):
+        seen["auth"] = req.get_header("Authorization")
+        seen["url"] = req.full_url
+        return _Resp()
+
+    monkeypatch.setattr(hs.urllib.request, "urlopen", fake_urlopen)
+    hs.HubSpotCRM().search_company(domain="x.io")
+    assert seen["auth"] == "Bearer pat-na2-test-000"
+    assert seen["url"].startswith("https://api.hubapi.com/crm/v3/objects/companies/search")
+
+
+def test_tenant_falls_back_to_fixture_without_key(monkeypatch):
+    monkeypatch.delenv("HUBSPOT_SERVICE_KEY", raising=False)
+    monkeypatch.delenv("HUBSPOT_API_KEY", raising=False)
+    fx = {"a1": Fixture("a1", "Acme", "acme.io", "company_identity", "pdl", "Acme Inc")}
+    t = RevenueIntelligenceTenant(fx, approver=lambda spec: False)
+    # with no key the crm provider is the offline ProviderTool: crm_enrich returns from the fixture,
+    # never the network — so enrich runs fully offline.
+    crm = t.registry.run("crm_enrich", {"account_id": "a1", "need": "company_identity"})
+    assert crm.ok and "live" not in crm.data           # offline ProviderTool, not HubSpotCRMTool
+    assert t.enrich("a1").outcome in ("correct", "wrong", "missing")
+
+
+@pytest.mark.skipif(not hs.token_present(), reason="no HubSpot Service Key in env")
+def test_live_search_smoke():
+    # only runs where a real key is exported; a broad no-op query should return without raising
+    hs.HubSpotCRM().search_company(domain="example-does-not-exist-zzz.io")

--- a/tests/test_revenue_intelligence.py
+++ b/tests/test_revenue_intelligence.py
@@ -1,0 +1,91 @@
+"""Revenue & Intelligence GTM tenant — offline, no API keys.
+
+Checks the load-bearing claims: the runtime learns the decisive provider per need, beats a fixed pipeline on
+quality at lower cost, penalises a confident wrong-entity match below a missing value, and denies outreach
+under NO_OUTREACH while allowing a draft.
+"""
+from __future__ import annotations
+
+from context_runtime.integrations.revenue_intelligence import (
+    DEFAULT_BUNDLES, DECISIVE_PROVIDER, Fixture, ProviderBundle, RevenueIntelligenceTenant,
+    _gtm_bandit, gtm_bucket, outcome_for, reward_enrich,
+)
+
+
+def _fixtures() -> dict[str, Fixture]:
+    return {f.account_id: f for f in [
+        Fixture("c1", "Acme", "acme.io", "company_identity", "pdl", "Acme Inc", wrong=("apollo",)),
+        Fixture("c2", "Beta", "beta.ai", "person_role", "apollo", "VP Eng"),
+        Fixture("c3", "Gamma", "gamma.dev", "tech_signal", "builtwith", "K8s + Snowflake"),
+        Fixture("c4", "Delta", "delta.co", "contact_verify", "hunter", "cto@delta.co"),
+        Fixture("c5", "Epsilon", "eps.com", "firmographics", "apollo", "Series B"),
+    ]}
+
+
+def test_bucket_classifier():
+    assert gtm_bucket("who is the decision maker / VP of data") == "person_role"
+    assert gtm_bucket("verify this email is deliverable") == "contact_verify"
+    assert gtm_bucket("what tech stack does the platform use") == "tech_signal"
+    assert gtm_bucket("resolve the canonical company / dedupe") == "company_identity"
+    assert gtm_bucket("employee count and funding stage") == "firmographics"
+
+
+def test_wrong_entity_penalised_below_missing():
+    fx = Fixture("x", "X", "x.io", "company_identity", "pdl", "X Inc", wrong=("apollo",))
+    only_wrong = ProviderBundle(("apollo",))          # confident wrong entity, no decisive source
+    nothing = ProviderBundle(("crm",))                # neither decisive nor wrong → missing
+    assert outcome_for(only_wrong, fx) == "wrong"
+    assert outcome_for(nothing, fx) == "missing"
+    assert reward_enrich("wrong", only_wrong) < reward_enrich("missing", nothing) == 0.0
+
+
+def test_decisive_present_beats_the_wrong_trap():
+    """If the decisive provider is in the bundle, verification wins even when a wrong provider is present."""
+    fx = Fixture("x", "X", "x.io", "company_identity", "pdl", "X Inc", wrong=("apollo",))
+    assert outcome_for(ProviderBundle(("apollo", "pdl")), fx) == "correct"
+
+
+def test_runs_offline_and_denies_outreach():
+    t = RevenueIntelligenceTenant(_fixtures(), approver=lambda spec: False, no_outreach=True)
+    r = t.enrich("c2")
+    assert r.outcome in ("correct", "wrong", "missing")
+    assert t.prepare_outreach("c2").ok is True                    # a draft is allowed
+    sent = t.send_outreach("c2")
+    assert sent.ok is False and "NO_OUTREACH" in sent.text        # sending is denied
+    assert t.registry.audit[-1]["allowed"] is False
+
+
+def test_learns_decisive_provider_per_need():
+    t = RevenueIntelligenceTenant(_fixtures(), bandit=_gtm_bandit(0.1), approver=lambda spec: False)
+    ids = list(_fixtures())
+    for i in range(200):
+        aid = ids[i % len(ids)]
+        t.record_outcome(aid, t.enrich(aid).outcome)
+    for need, decisive in DECISIVE_PROVIDER.items():
+        if need in t.policy():
+            key = t.policy()[need]
+            bundle = next(b for b in DEFAULT_BUNDLES if b.key == key)
+            assert decisive in bundle.providers, f"{need}: learned {key} lacks decisive {decisive}"
+
+
+def test_adaptive_beats_fixed_pipeline():
+    fx = _fixtures()
+    t = RevenueIntelligenceTenant(fx, bandit=_gtm_bandit(0.1), approver=lambda spec: False)
+    ids = list(fx)
+    for i in range(200):
+        aid = ids[i % len(ids)]
+        t.record_outcome(aid, t.enrich(aid).outcome)
+
+    fixed = ProviderBundle(("crm", "apollo", "pdl"))              # misses hunter + builtwith
+    fixed_correct = sum(outcome_for(fixed, f) == "correct" for f in fx.values())
+    adaptive_correct = 0
+    adaptive_cost = 0.0
+    for f in fx.values():
+        bundle = next(b for b in DEFAULT_BUNDLES if b.key == t.policy()[f.need])
+        adaptive_correct += int(outcome_for(bundle, f) == "correct")
+        adaptive_cost += bundle.cost
+    n = len(fx)
+    # adaptive resolves every need (fixed pipeline cannot) at a lower average cost than the fixed set
+    assert adaptive_correct >= fixed_correct
+    assert adaptive_correct == n
+    assert adaptive_cost / n <= fixed.cost

--- a/tests/test_revenue_intelligence.py
+++ b/tests/test_revenue_intelligence.py
@@ -7,8 +7,8 @@ under NO_OUTREACH while allowing a draft.
 from __future__ import annotations
 
 from context_runtime.integrations.revenue_intelligence import (
-    DEFAULT_BUNDLES, DECISIVE_PROVIDER, Fixture, ProviderBundle, RevenueIntelligenceTenant,
-    _gtm_bandit, gtm_bucket, outcome_for, reward_enrich,
+    DEFAULT_BUNDLES, DEFAULT_POPULATION_RULES, DECISIVE_PROVIDER, Fixture, GtmPopulationGovernor,
+    ProviderBundle, RevenueIntelligenceTenant, _gtm_bandit, gtm_bucket, outcome_for, reward_enrich,
 )
 
 
@@ -27,7 +27,41 @@ def test_bucket_classifier():
     assert gtm_bucket("verify this email is deliverable") == "contact_verify"
     assert gtm_bucket("what tech stack does the platform use") == "tech_signal"
     assert gtm_bucket("resolve the canonical company / dedupe") == "company_identity"
-    assert gtm_bucket("employee count and funding stage") == "firmographics"
+    assert gtm_bucket("employee count and industry") == "firmographics"
+    assert gtm_bucket("what series did they raise, and which investors") == "funding_signal"
+    assert gtm_bucket("something mentioned on a niche forum / open web") == "niche_signal"
+
+
+def _segmented_fixtures() -> dict[str, Fixture]:
+    """person_role and firmographics have a segment-dependent decisive provider — so a need-only policy
+    can't be optimal but a need×segment policy can."""
+    return {f.account_id: f for f in [
+        Fixture("s1", "EntA", "enta.com", "person_role", "apollo", "VP", segment="enterprise"),
+        Fixture("s2", "EntB", "entb.com", "person_role", "apollo", "CTO", segment="enterprise"),
+        Fixture("s3", "SmbA", "smba.io", "person_role", "pdl", "Founder", segment="smb"),
+        Fixture("s4", "SmbB", "smbb.io", "person_role", "pdl", "Eng", segment="smb"),
+        Fixture("s5", "PubA", "puba.com", "funding_signal", "sec", "10-K", segment="public"),
+        Fixture("s6", "PrivA", "priva.io", "funding_signal", "crunchbase", "Series C", segment="private"),
+    ]}
+
+
+def _train(fixtures, segmented, rounds=400) -> RevenueIntelligenceTenant:
+    t = RevenueIntelligenceTenant(fixtures, bandit=_gtm_bandit(0.1), approver=lambda spec: False,
+                                  segmented=segmented)
+    ids = list(fixtures)
+    for i in range(rounds):
+        t.record_outcome(ids[i % len(ids)], t.enrich(ids[i % len(ids)]).outcome)
+    return t
+
+
+def _eval(t, fixtures) -> tuple[int, float]:
+    correct = 0
+    cost = 0.0
+    for fx in fixtures.values():
+        bundle = next(b for b in DEFAULT_BUNDLES if b.key == t.policy()[t._ctx(fx, fx.need)])
+        correct += int(outcome_for(bundle, fx) == "correct")
+        cost += bundle.cost
+    return correct, cost
 
 
 def test_wrong_entity_penalised_below_missing():
@@ -89,3 +123,39 @@ def test_adaptive_beats_fixed_pipeline():
     assert adaptive_correct >= fixed_correct
     assert adaptive_correct == n
     assert adaptive_cost / n <= fixed.cost
+
+
+def test_learned_arm_f_cheaper_than_e_at_equal_quality():
+    """Phase 3: conditioning on segment (arm F) resolves every need at strictly lower cost than the
+    need-only policy (arm E), because E must buy a segment-covering bundle where F buys the cheap single."""
+    fx = _segmented_fixtures()
+    e_correct, e_cost = _eval(_train(fx, segmented=False), fx)
+    f_correct, f_cost = _eval(_train(fx, segmented=True), fx)
+    assert f_correct == e_correct == len(fx)      # both fully correct
+    assert f_cost < e_cost                         # F strictly cheaper
+
+
+def test_population_governor_detects_regression_and_is_observe_enforce_equivalent():
+    """Phase 4 (arm G): a healthy stream is clean; a batch escalating to the expensive fallback trips the
+    provider-storm + cost-runaway rules; OBSERVE and ENFORCE detect identically."""
+    healthy = [{"account_id": f"h{i}", "need": "person_role", "segment": "smb",
+                "bundle": "pdl", "providers": ("pdl",), "cost": 0.05, "outcome": "correct"} for i in range(20)]
+    assert GtmPopulationGovernor(mode="OBSERVE").evaluate(healthy) == []
+
+    regression = [{"account_id": f"r{i}", "need": "firmographics", "segment": "smb",
+                   "bundle": "apollo+web_research", "providers": ("apollo", "web_research"),
+                   "cost": 0.32, "outcome": "correct"} for i in range(8)]
+    observe = GtmPopulationGovernor(DEFAULT_POPULATION_RULES, mode="OBSERVE").evaluate(regression)
+    enforce = GtmPopulationGovernor(DEFAULT_POPULATION_RULES, mode="ENFORCE").evaluate(regression)
+    rules = {f.rule for f in observe}
+    assert "expensive-provider storm" in rules and "cost runaway" in rules
+    assert [(f.rule, f.disposition) for f in observe] == [(f.rule, f.disposition) for f in enforce]
+
+
+def test_governor_provider_storm_counts_distinct_accounts():
+    """distinct_on=account_id: one account escalating many times is not a storm."""
+    spammy_one = [{"account_id": "a1", "need": "niche_signal", "segment": "default",
+                   "bundle": "web_research", "providers": ("web_research",), "cost": 0.30,
+                   "outcome": "correct"} for _ in range(20)]
+    findings = GtmPopulationGovernor(DEFAULT_POPULATION_RULES, mode="OBSERVE").evaluate(spammy_one)
+    assert "expensive-provider storm" not in {f.rule for f in findings}

--- a/tests/test_salesforce_crm.py
+++ b/tests/test_salesforce_crm.py
@@ -1,0 +1,108 @@
+"""Salesforce CRM connector — offline unit tests (no network, no creds required)."""
+from __future__ import annotations
+
+import pytest
+
+from context_runtime.integrations import salesforce_crm as sf
+from context_runtime.integrations.revenue_intelligence import Fixture
+
+
+def _clear(monkeypatch):
+    for k in ("SALESFORCE_CONSUMER_KEY", "SALESFORCE_CONSUMER_SECRET", "SALESFORCE_INSTANCE_URL",
+              "SALESFORCE_CLIENT_ID", "SALESFORCE_CLIENT_SECRET"):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_no_creds_reports_unavailable(monkeypatch):
+    _clear(monkeypatch)
+    assert sf.token_present() is False
+    fx = {"a1": Fixture("a1", "Acme", "acme.io", "company_identity", "crm", "Acme")}
+    res = sf.SalesforceCRMTool(fx).run({"account_id": "a1", "need": "company_identity"})
+    assert res.ok and res.data["status"] == "missing" and res.data["live"] is False
+
+
+def test_client_credentials_token_request(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("SALESFORCE_CONSUMER_KEY", "ck")
+    monkeypatch.setenv("SALESFORCE_CONSUMER_SECRET", "cs")
+    monkeypatch.setenv("SALESFORCE_INSTANCE_URL", "https://x.my.salesforce.com")
+    seen = {}
+
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self):
+            return b'{"access_token": "TOKEN123", "instance_url": "https://x.my.salesforce.com"}'
+
+    def fake_urlopen(req, timeout=20):
+        seen["url"] = req.full_url
+        seen["body"] = req.data.decode()
+        return _Resp()
+
+    monkeypatch.setattr(sf.urllib.request, "urlopen", fake_urlopen)
+    client = sf.SalesforceCRM()
+    client._fetch_token()
+    assert client._token == "TOKEN123"
+    assert seen["url"] == "https://x.my.salesforce.com/services/oauth2/token"
+    assert "grant_type=client_credentials" in seen["body"]
+    assert "client_id=ck" in seen["body"] and "client_secret=cs" in seen["body"]
+
+
+def test_soql_and_bearer_on_query(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("SALESFORCE_CONSUMER_KEY", "ck")
+    monkeypatch.setenv("SALESFORCE_CONSUMER_SECRET", "cs")
+    monkeypatch.setenv("SALESFORCE_INSTANCE_URL", "https://x.my.salesforce.com")
+    seen = {}
+
+    class _Resp:
+        def __init__(self, payload): self._p = payload
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self._p
+
+    def fake_urlopen(req, timeout=20):
+        if req.full_url.endswith("/token"):
+            return _Resp(b'{"access_token": "T", "instance_url": "https://x.my.salesforce.com"}')
+        seen["auth"] = req.get_header("Authorization")
+        seen["url"] = req.full_url
+        return _Resp(b'{"records": [{"Id": "001", "Name": "Acme", "Website": "acme.io"}]}')
+
+    monkeypatch.setattr(sf.urllib.request, "urlopen", fake_urlopen)
+    acct = sf.SalesforceCRM().search_account(domain="acme.io")
+    assert acct["Id"] == "001"
+    assert seen["auth"] == "Bearer T"
+    assert "/services/data/" in seen["url"] and "query?q=" in seen["url"]
+    assert "Website+LIKE" in seen["url"] or "Website%20LIKE" in seen["url"]
+
+
+def test_token_refresh_on_401(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("SALESFORCE_CONSUMER_KEY", "ck")
+    monkeypatch.setenv("SALESFORCE_CONSUMER_SECRET", "cs")
+    monkeypatch.setenv("SALESFORCE_INSTANCE_URL", "https://x.my.salesforce.com")
+    state = {"api_calls": 0, "tokens": 0}
+
+    class _Resp:
+        def __init__(self, payload): self._p = payload
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self._p
+
+    def fake_urlopen(req, timeout=20):
+        if req.full_url.endswith("/token"):
+            state["tokens"] += 1
+            return _Resp(b'{"access_token": "T", "instance_url": "https://x.my.salesforce.com"}')
+        state["api_calls"] += 1
+        if state["api_calls"] == 1:
+            raise sf.urllib.error.HTTPError(req.full_url, 401, "expired", {}, None)
+        return _Resp(b'{"records": []}')
+
+    monkeypatch.setattr(sf.urllib.request, "urlopen", fake_urlopen)
+    sf.SalesforceCRM().query("SELECT Id FROM Account")
+    assert state["tokens"] == 2 and state["api_calls"] == 2   # refreshed once, retried once
+
+
+@pytest.mark.skipif(not sf.token_present(), reason="no Salesforce credentials in env")
+def test_live_query_smoke():
+    sf.SalesforceCRM().search_account(domain="example-does-not-exist-zzz.io")


### PR DESCRIPTION
The GTM benchmark from `redevops-revenue-intelligence-runtime-benchmark-plan.md` as a Context Runtime tenant, following the edge-sentinel pattern — **offline, no API keys**.

**Decision:** which providers to call for an enrichment need. **Reward:** correct enrichment at the cheapest sufficient bundle; a confident **wrong-entity** match is penalised *below* a missing value (a wrong company is worse than a blank). **Governance:** outreach `send` is approval-gated and denied under `NO_OUTREACH`; `prepare` (draft) is allowed.

**Offline result** (`examples/revenue_intelligence.py`, 15 labelled accounts):

| arm | quality | $/acct | paid calls |
|---|--:|--:|--:|
| A  all providers | 100% | 0.140 | 60 |
| B  fixed pipeline | 60% | 0.070 | 30 |
| C  cheapest-first | 0% | 0.000 | 0 |
| **E  ReDevOps adaptive** | **100%** | **0.032** | **15** |

Adaptive (E) vs fixed pipeline (B): **+40 quality points, −54% cost/account, half the paid calls** — and it matches the all-providers quality ceiling at 23% of its cost. It learns the decisive provider per need (pdl/apollo/hunter/builtwith). This is the plan's first publishable question, answered.

**Scope:** Phase 0 + arm E (offline foundation). Phase 2–5 — more providers (BuiltWith/SEC/web-research), learned arm F from observed provider stats, population-governance arm G (`PopulationRule`: provider-storm / source-monoculture), and live connectors — follow.

`contextos pytest` green (6 new tests + full suite). Registered in the fleet CATALOG. Not merged — off `main`, for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)