### PR TITLE
Geospatial capability v0.3.x: typed spatial evidence + deterministic engine + zoning-intelligence tenant

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,6 +131,7 @@ contracts.
 | **Policy (5.10)** | **Open Policy Agent (Rego)** + **Presidio** (PII) | §5.10 YAML → Rego; `safety.py` stays as fast inline pre-filter. |
 | **Token counting (5.11)** | `tiktoken` + provider tokenizers (LiteLLM) | — |
 | **Observability (5.12)** | **OpenTelemetry + OpenLLMetry** → **Langfuse** | Self-hostable trace/cost/eval + replay (principle #7). Alt: Arize **Phoenix**. |
+| **Geospatial / spatial (§5, v0.3.x)** | CPU engine (`geospatial/engine.py`) · **Shapely/GeoPandas · PostGIS · DuckDB-Spatial** | Typed spatial evidence (`GeoRef`) + spatial ops (point-in-polygon, intersects, spatial-join, distance) as planner-selectable capabilities. The pure-Python engine is the authoritative default; heavier/GPU backends are selected on measured crossover — the accelerator changes latency, not the geometric answer. |
 | **Execution (5.8 / §4)** | **Dagster** | Runs the Execution Graph; Context Runtime *decides* it. |
 | **Optimizer (§6)** | **OR-Tools CP-SAT** · **Optuna** · **River** · (Ray Tune later) | Constrained selection · offline tuning · online contextual bandits. |
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -61,6 +61,31 @@ per-app tenant demos all ran green: `agentic_billing, agentic_books, agentic_com
 agentic_support, control_tower, market_radar, growth_engine, social_autopilot, outreach_engine,
 outreach_pipeline, incident_review, soc_triage, sidekick_learning, vibexgen_learning`.
 
+## 6a. Zoning intelligence — the geospatial reference benchmark (`examples/zoning_intelligence.py`)
+
+Given a parcel and a target use, the Runtime concludes the land-use disposition (PERMITTED / CONDITIONAL /
+PROHIBITED / UNKNOWN) from heterogeneous evidence (Regrid · ATTOM · official municipal GIS · zoning
+ordinance) and learns *which evidence to acquire* per use-difficulty bucket. Deterministic geometry and
+structured constraints are reconciled by the CPU spatial engine before any ordinance/LLM interpretation,
+and PERMITTED is only ever concluded when the evidence is sufficient to confirm it — so a single stale
+provider can never produce a "verified permitted" (the blocking SLO `false-permitted = 0`, plan §16).
+
+Measured (single run, `PYTHONPATH=. python examples/zoning_intelligence.py`):
+
+| arm | reward | avg evidence cost | false-permits |
+|---|---|---|---|
+| **C · Context Runtime (learned bundle/bucket)** | **+0.894** | **5.67u** | **0** |
+| A · single provider (Regrid only) | +0.080 | 1.00u | **1 ← violates SLO** |
+| B · fixed thorough (all sources) | +0.850 | 8.00u | 0 |
+
+The learned policy uses the official GIS for residential/commercial but reserves the expensive ordinance
+for the industrial (conditional-use) bucket — matching B's correctness at **1.4× lower evidence cost**,
+and beating single-provider by **+0.814 reward with 0 SLO violations vs 1**. The same run demonstrates the
+deterministic-first constraint (a data center on an undersized lot is PROHIBITED before interpretation),
+use-first land search (spatial prefilter + learned evidence), dependency-scoped incremental recomputation
+(a new overlay recomputes 1 of 9 parcels), and population-governance drift detection (a provider drifting
+CONDITIONAL→PERMITTED across the population → REQUIRE_REVIEW).
+
 ## Full run table
 
 All 30 scripts exited 0. Slowest: `consolidated_benchmark` (14s, runs the Go twin), `dspark_calibration_bench` (12s).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.3.x — geospatial capabilities + zoning intelligence (unreleased)
+
+Geospatial support as a **Runtime capability, not a separate Geospatial Runtime**: a parcel's geometry,
+CRS, jurisdiction and temporal state become typed evidence, and spatial operations become capabilities
+the planner selects, composes, verifies and governs. Fully additive and offline; no existing path changes.
+
+**What is now true**
+
+- **Typed spatial evidence** (`context_runtime.geospatial.contracts`): `GeoRef` (geometry identity via a
+  canonical, hashable `geometry_hash`; explicit CRS; jurisdiction; valid/observed time) extends — never
+  replaces — the evidence-native model. Domain vocabulary: `ParcelEntity`, `UseDisposition`
+  (PERMITTED / CONDITIONAL / SPECIAL_EXCEPTION / PROHIBITED / **UNKNOWN**), `LandUseConstraint`, a
+  normalized use ontology.
+- **CPU-authoritative spatial engine** (`context_runtime.geospatial.engine`): pure-Python, exact,
+  dependency-free point-in-polygon, polygon intersection, area, centroid, distance, and centroid spatial
+  join. Binary ops **refuse a silent CRS mismatch** (raise so the planner inserts an explicit REPROJECT).
+  Heavier backends (shapely/PostGIS/DuckDB-Spatial/GPU) are planner-selectable on measured crossover —
+  the accelerator changes latency, never the answer.
+- **Zoning-intelligence tenant** (`context_runtime.integrations.zoning_intelligence` +
+  `examples/zoning_intelligence.py`): the geospatial reference benchmark. The Runtime learns *which
+  evidence to acquire* (Regrid · ATTOM · official GIS · ordinance) per use-difficulty bucket. A
+  deterministic-first, fail-safe resolver reconciles evidence and only concludes PERMITTED when the
+  evidence is sufficient — making **false-permitted a structural impossibility** for reconciled bundles
+  (the blocking SLO). Measured: learned **+0.894 reward at 1.4× lower evidence cost** than
+  always-thorough, **0 false-permits vs 1** for single-provider. Includes use-first land search,
+  dependency-scoped incremental recomputation, and population-governance drift detection.
+
 ## 0.2.0 — freshness sourced from evidence (v0.2.x final stabilization)
 
 Correctness/completeness fix to functionality v0.2.x already advertised. The freshness *scoring*, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## 0.3.x — geospatial capabilities + zoning intelligence (unreleased)
+## 0.3.x — unreleased
+
+The 0.3.x line is additive and default-serial throughout: each new path is opt-in and
+byte-for-byte the previous behavior unless enabled. This "Unreleased" section accumulates
+the v0.3.x work staged across the coordinated-release feature branches, so both the
+geospatial and the concurrency entries appear here on every 0.3.x branch (which is also
+what keeps this file merge-clean).
+
+### Geospatial capabilities + zoning intelligence
 
 Geospatial support as a **Runtime capability, not a separate Geospatial Runtime**: a parcel's geometry,
 CRS, jurisdiction and temporal state become typed evidence, and spatial operations become capabilities
 the planner selects, composes, verifies and governs. Fully additive and offline; no existing path changes.
-
-**What is now true**
 
 - **Typed spatial evidence** (`context_runtime.geospatial.contracts`): `GeoRef` (geometry identity via a
   canonical, hashable `geometry_hash`; explicit CRS; jurisdiction; valid/observed time) extends — never
@@ -26,6 +32,19 @@ the planner selects, composes, verifies and governs. Fully additive and offline;
   (the blocking SLO). Measured: learned **+0.894 reward at 1.4× lower evidence cost** than
   always-thorough, **0 false-permits vs 1** for single-provider. Includes use-first land search,
   dependency-scoped incremental recomputation, and population-governance drift detection.
+
+### Opt-in reasoner + retrieval concurrency
+
+The independent calls a plan already makes now overlap instead of running strictly one after another.
+
+- **Reasoner fork/join** (`context_runtime/reasoner/_concurrency.py`): a mixture strategy's independent
+  model calls — `debate` passes, `plan_worker_critic` workers, self-consistency samples — fan out
+  concurrently when `CR_REASONER_CONCURRENCY>1` (default 1 = serial). Order-preserving, so the
+  judge/critic/vote reconciliation sees identical inputs in identical order — the answer is unchanged,
+  only wall-clock. Concurrency is *how* a strategy's calls run, never *which* calls it makes.
+- **Retrieval overlap** (`context_runtime/_parallel.py`): the hybrid BM25 ∥ vector legs and the
+  two-stage stage-1 recalls overlap when `CR_RETRIEVAL_CONCURRENCY>1` (default 1 = serial),
+  order-preserved so RRF fusion is deterministic regardless of the setting.
 
 ## 0.2.0 — freshness sourced from evidence (v0.2.x final stabilization)
 

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -56,12 +56,15 @@ the *arms* (what to choose) and the *reward* (how to score it) are app-specific.
 | **sidekick** (coding agent) | which skills to recall · bundle size · token budget | acceptance rate · first-try · tokens | **built, green** — drop-in for `SkillStore`; 67% vs 33% naive baseline |
 | **redevops-rag** (retrieval) | `pool · limit · vector_threshold · recency · keyword priors · rerank` per query intent | retrieval quality − efficiency penalty | **built, green** — `ContextRuntimeRetrieverTuner`; 0.780 vs 0.428 fixed default |
 | **edge-sentinel** (SOC) | which sources to pull per alert (CrowdSec · threat-intel · EDR) | correct verdict − source cost | **built, green** — tool-using + approval-gated; 0.900 vs 0.800 always-full |
+| **zoning-intelligence** (geospatial) | which evidence bundle to acquire per use-difficulty bucket (Regrid · ATTOM · official GIS · ordinance) | correct land-use disposition − evidence cost | **built, green** — deterministic-first + reconciliation; 0.894 vs 0.850 always-thorough at 1.4× cheaper, 0 false-permits vs 1 |
 | **business modules** (billing · support · BI · compliance …) | which sources/cores to query · which model tier | task success · cost-per-good-answer | **now built** — each is a tenant with a goal + a metric (see the full fleet) |
 
 These prove the pattern generalizes across very different decision types: sidekick
 chooses among **discrete strategies**, redevops-rag tunes **numeric knobs**,
-edge-sentinel selects **sources/tools with side effects**. Same bandit, same
-cost-model, same wrap. That is the whole bet.
+edge-sentinel selects **sources/tools with side effects**, and zoning-intelligence
+does **deterministic-first spatial evidence acquisition** (geometry reconciled before
+any LLM, abstaining to `UNKNOWN` rather than risk a false conclusion). Same bandit,
+same cost-model, same wrap. That is the whole bet.
 
 **Context Runtime *is* the control plane.** It absorbs the earlier `agentic-os` fleet-controller logic — the routing, approval/safety,
 and audit-log capabilities prototyped there now live natively in Context Runtime (agentic-os

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -51,13 +51,11 @@ the *arms* (what to choose) and the *reward* (how to score it) are app-specific.
 
 ## The tenants (all redevops repos)
 
-| Tenant | Decision point Context Runtime optimizes | Reward (the app's own metric) | Status |
-|---|---|---|---|
-| **sidekick** (coding agent) | which skills to recall · bundle size · token budget | acceptance rate · first-try · tokens | **built, green** — drop-in for `SkillStore`; 67% vs 33% naive baseline |
-| **redevops-rag** (retrieval) | `pool · limit · vector_threshold · recency · keyword priors · rerank` per query intent | retrieval quality − efficiency penalty | **built, green** — `ContextRuntimeRetrieverTuner`; 0.780 vs 0.428 fixed default |
-| **edge-sentinel** (SOC) | which sources to pull per alert (CrowdSec · threat-intel · EDR) | correct verdict − source cost | **built, green** — tool-using + approval-gated; 0.900 vs 0.800 always-full |
-| **zoning-intelligence** (geospatial) | which evidence bundle to acquire per use-difficulty bucket (Regrid · ATTOM · official GIS · ordinance) | correct land-use disposition − evidence cost | **built, green** — deterministic-first + reconciliation; 0.894 vs 0.850 always-thorough at 1.4× cheaper, 0 false-permits vs 1 |
-| **business modules** (billing · support · BI · compliance …) | which sources/cores to query · which model tier | task success · cost-per-good-answer | **now built** — each is a tenant with a goal + a metric (see the full fleet) |
+The full, current fleet table — each tenant's decision point, reward, and measured
+learned-vs-baseline delta — lives in the [README](./README.md) and
+[BENCHMARKS.md](./BENCHMARKS.md), which are the single source for those numbers; this
+doc does not restate them, so they cannot drift out of sync. What matters *for
+positioning* is the spread of decision types the fleet already covers:
 
 These prove the pattern generalizes across very different decision types: sidekick
 chooses among **discrete strategies**, redevops-rag tunes **numeric knobs**,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ green (each number is the learned-vs-baseline reward its offline example in `exa
 | **redevops-rag** | `pool · limit · threshold · rerank …` per query | `ContextRuntimeRetrieverTuner`; **0.780 vs 0.428** vs fixed default |
 | **edge-sentinel (SOC)** | which sources to pull per alert (CrowdSec · threat-intel · EDR) | tool-using + approval-gated; **0.900 vs 0.800** always-full baseline |
 | **video-ad** | which generation chain (provider · detail · best-of-N) per shot-complexity bucket | learns the cheapest creative path to an *accepted* segment; **0.853 vs 0.777** premium baseline at **4.5× cheaper spend** |
+| **zoning-intelligence** (geospatial) | which evidence bundle (Regrid · ATTOM · official GIS · ordinance) per use-difficulty bucket | deterministic-first + reconciliation; **0.894 vs 0.850** always-thorough at **1.4× cheaper**, and **0 false-permits vs 1** for single-provider (the blocking SLO) |
 | **growth-engine** | which attribution window + source bundle per lead-source query | **7.851 vs 5.282** vs fixed window |
 | **control-tower** | which Metabase query set per "ask anything" question | **5.326 vs 1.643** vs core query set |
 | **agentic-billing** | which usage/invoice/dunning signals to pull per account | **4.122 vs 2.442** vs full-stack |
@@ -36,6 +37,7 @@ PYTHONPATH=. python examples/sidekick_learning.py   # discrete-strategy bandit
 PYTHONPATH=. python examples/rag_tuning.py          # numeric-knob tuning
 PYTHONPATH=. python examples/soc_triage.py          # tool-using cybersecurity tenant
 PYTHONPATH=. python examples/video_ad.py            # creative-workflow chain optimization
+PYTHONPATH=. python examples/zoning_intelligence.py # geospatial: deterministic-first spatial evidence
 ```
 
 Plus the **ToolPlugin** seam (`context_runtime/tools/` — how plans reach external systems,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,6 +130,13 @@ the graph informs selection; CP-SAT finds feasible plans where greedy knapsack f
 **Goal:** the cost model *learns* from observed outcomes. This is where Context Runtime
 stops being a clever static planner and becomes a runtime that improves.
 
+> **Also landed in 0.3.x (additive):** *Geospatial capabilities* — typed spatial evidence
+> (`GeoRef`) + a CPU-authoritative spatial engine + the **zoning-intelligence** tenant
+> (deterministic-first evidence acquisition; see [CHANGELOG](CHANGELOG.md) and
+> [BENCHMARKS §6a](BENCHMARKS.md)). *Opt-in reasoner/retrieval concurrency* — independent
+> reasoning passes and retrieval legs overlap (default-serial; `CR_REASONER_CONCURRENCY` /
+> `CR_RETRIEVAL_CONCURRENCY`).
+
 - Memory (the lifecycle sub-concern of the Knowledge Layer) → migrate mem0 →
   **Graphiti (Zep)** bi-temporal KG: versioned, auditable, contradiction detection,
   expiration, promotion, compaction.

--- a/context_runtime/geospatial/__init__.py
+++ b/context_runtime/geospatial/__init__.py
@@ -1,0 +1,20 @@
+"""Geospatial capabilities (v0.3.x) — typed spatial evidence + planner-selectable spatial operations.
+
+Geospatial support is a **Runtime capability, not a separate Geospatial Runtime**: a parcel's geometry,
+CRS, jurisdiction and temporal state become typed evidence (`GeoRef`), and spatial operations
+(point-in-polygon, intersects, spatial-join, distance, …) become capabilities the planner selects,
+composes, verifies and governs. The governing rule:
+
+    Do not ask an LLM to infer a spatial relationship a deterministic geometry engine can calculate.
+
+The reference engine is pure-Python and deterministic (`engine.py`); heavier backends (shapely/GeoPandas,
+PostGIS, DuckDB-Spatial, a GPU implementation) are optional and planner-selectable on measured crossover,
+exactly like the cuVS/cuDF accelerators — the *result* never changes, only how fast it is produced.
+
+Reference workload: **zoning intelligence** (`integrations/zoning_intelligence.py`) — parcel-first ("what
+can I build here?") and use-first ("find compatible parcels"), reconciling parcel/zoning/ordinance
+evidence across providers while preserving provenance, uncertainty and review requirements.
+"""
+from .contracts import (  # noqa: F401
+    GeoRef, SpatialOp, UseDisposition, ConstraintType, ParcelEntity, LandUseConstraint, USE_ONTOLOGY,
+)

--- a/context_runtime/geospatial/contracts.py
+++ b/context_runtime/geospatial/contracts.py
@@ -1,0 +1,126 @@
+"""Geospatial contracts (plan §2, §8-10): typed spatial evidence + the zoning/parcel domain model.
+
+`GeoRef` is the typed geospatial reference that rides alongside evidence — it does NOT replace EvidenceRef,
+it extends the evidence-native model with geometry identity, CRS, jurisdiction and spatiotemporal state.
+Geometry has a canonical hash so the same parcel boundary is one identity across providers, and reprojection
+is explicit and auditable (never a silent CRS mismatch).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+
+Coord = tuple[float, float]                    # (lon, lat) or (x, y) in the ring's CRS
+Ring = list[Coord]                             # a closed ring (first==last not required; we close it)
+
+
+# ──────────────────────────── spatial operations (the capabilities) ────────────────────────────
+
+class SpatialOp(str, Enum):
+    POINT_IN_POLYGON = "POINT_IN_POLYGON"
+    INTERSECTS = "INTERSECTS"
+    WITHIN = "WITHIN"
+    CONTAINS = "CONTAINS"
+    OVERLAPS = "OVERLAPS"
+    TOUCHES = "TOUCHES"
+    DISTANCE = "DISTANCE"
+    NEAREST = "NEAREST"
+    BUFFER = "BUFFER"
+    CENTROID = "CENTROID"
+    SPATIAL_JOIN = "SPATIAL_JOIN"
+    BBOX_QUERY = "BBOX_QUERY"
+    REPROJECT = "REPROJECT"
+    AREA = "AREA"
+
+
+# ──────────────────────────── typed spatial evidence ────────────────────────────
+
+def geometry_hash(rings: list[Ring], crs: str) -> str:
+    """Canonical, stable identity for a geometry — rounded coords + CRS, hashed. Same boundary in the same
+    CRS → same id across providers, so parcel identity is not provider-specific."""
+    # normalise to float so an int coord (0) and its float twin (0.0) hash identically
+    norm = [[[round(float(x), 7), round(float(y), 7)] for x, y in ring] for ring in rings]
+    payload = json.dumps({"crs": crs, "rings": norm}, sort_keys=True, separators=(",", ":"))
+    return "geo:" + hashlib.blake2b(payload.encode(), digest_size=16).hexdigest()
+
+
+@dataclass(frozen=True)
+class GeoRef:
+    """A typed geospatial reference carried with evidence (plan §2). Extends, not replaces, EvidenceRef."""
+    geometry_type: str                         # "Polygon" | "Point" | "MultiPolygon"
+    geometry_hash: str                         # canonical hashable identity (from geometry_hash())
+    crs: str                                   # explicit CRS/SRID, e.g. "EPSG:4326"
+    bbox: tuple[float, float, float, float]    # (minx, miny, maxx, maxy)
+    centroid: Coord
+    jurisdiction: str = ""
+    spatial_resolution: float | None = None
+    horizontal_accuracy: float | None = None
+    valid_time: str = ""                       # world-time validity (ISO); "" = -inf
+    observed_at: str = ""                      # when observed/recorded (transaction time)
+    source: str = ""
+    source_version: str = ""
+
+
+# ──────────────────────────── zoning / parcel domain (plan §8-10) ────────────────────────────
+
+class UseDisposition(str, Enum):
+    """How a use maps against a parcel's rules — never forced into a binary (plan §9)."""
+    PERMITTED = "PERMITTED"
+    CONDITIONAL = "CONDITIONAL"
+    SPECIAL_EXCEPTION = "SPECIAL_EXCEPTION"
+    PROHIBITED = "PROHIBITED"
+    UNKNOWN = "UNKNOWN"
+
+
+# Normalized use ontology (plan §9) — a starter set; jurisdictions map their local rules onto these.
+USE_ONTOLOGY: tuple[str, ...] = (
+    "RESIDENTIAL_SINGLE_FAMILY", "RESIDENTIAL_MULTI_FAMILY", "MIXED_USE", "OFFICE", "RETAIL", "RESTAURANT",
+    "HOTEL", "LIGHT_INDUSTRIAL", "HEAVY_INDUSTRIAL", "WAREHOUSE", "LOGISTICS", "AGRICULTURE", "SELF_STORAGE",
+    "DATA_CENTER", "MEDICAL", "EDUCATION", "RELIGIOUS", "ENTERTAINMENT", "PARKING", "SOLAR", "EV_CHARGING",
+)
+
+
+class ConstraintType(str, Enum):
+    MIN_LOT_AREA = "MIN_LOT_AREA"
+    MIN_LOT_WIDTH = "MIN_LOT_WIDTH"
+    MAX_HEIGHT = "MAX_HEIGHT"
+    MAX_FAR = "MAX_FAR"
+    MAX_LOT_COVERAGE = "MAX_LOT_COVERAGE"
+    FRONT_SETBACK = "FRONT_SETBACK"
+    SIDE_SETBACK = "SIDE_SETBACK"
+    REAR_SETBACK = "REAR_SETBACK"
+    MAX_DENSITY = "MAX_DENSITY"
+    PARKING_MINIMUM = "PARKING_MINIMUM"
+    FLOOD_RESTRICTION = "FLOOD_RESTRICTION"
+    OVERLAY_RESTRICTION = "OVERLAY_RESTRICTION"
+
+
+@dataclass(frozen=True)
+class LandUseConstraint:
+    """A development control tested against a project spec — not just a zoning label (plan §10)."""
+    type: ConstraintType
+    value: float | str
+    unit: str = ""
+    operator: str = ">="                       # ">=", "<=", "==" …
+    source_evidence: str = ""
+    confidence: float = 1.0
+
+
+@dataclass
+class ParcelEntity:
+    """Canonical parcel with provenance kept visible — the canonical value is a conclusion; provider records
+    remain evidence (plan §8). Provider disagreement is never flattened away."""
+    parcel_id: str                             # canonical (geometry_hash-based) id
+    geometry_ref: GeoRef
+    apn: str = ""
+    address: str = ""
+    jurisdiction: str = ""
+    lot_area: float | None = None              # in the parcel's CRS/area units
+    provider_ids: dict[str, str] = field(default_factory=dict)      # provider -> their record id
+    zoning_codes: list[str] = field(default_factory=list)          # raw codes seen across providers
+    zoning_districts: list[str] = field(default_factory=list)
+    overlays: list[str] = field(default_factory=list)
+    constraints: list[LandUseConstraint] = field(default_factory=list)
+    evidence_refs: list[str] = field(default_factory=list)

--- a/context_runtime/geospatial/contracts.py
+++ b/context_runtime/geospatial/contracts.py
@@ -7,60 +7,69 @@ is explicit and auditable (never a silent CRS mismatch).
 """
 from __future__ import annotations
 
-import hashlib
-import json
 from dataclasses import dataclass, field
 from enum import Enum
 
-Coord = tuple[float, float]                    # (lon, lat) or (x, y) in the ring's CRS
-Ring = list[Coord]                             # a closed ring (first==last not required; we close it)
+# The typed spatial-evidence primitive (GeoRef, geometry_hash, SpatialOp) is a canonical, cross-runtime
+# contract, promoted to the shared `runtime-contracts` package (0.3.x). Import it from there when it is
+# installed alongside — that package is the single source of truth. When Context Runtime runs standalone
+# (runtime-contracts not on the path), fall back to a byte-identical local definition so nothing breaks;
+# the local geometry_hash reproduces the shared one exactly (proven by the shared golden vectors).
+try:
+    from runtime_contracts.protocol.geospatial import (   # noqa: F401 — re-exported for local callers
+        Coord,
+        Ring,
+        SpatialOp,
+        GeoRef,
+        geometry_hash,
+        GEOMETRY_PRECISION,
+    )
+except ImportError:  # pragma: no cover - exercised only where runtime-contracts is absent
+    import hashlib
+    import json
 
+    Coord = tuple[float, float]                # (lon, lat) or (x, y) in the ring's CRS
+    Ring = list[Coord]                         # a ring (first==last not required; we close it)
+    GEOMETRY_PRECISION = 7
 
-# ──────────────────────────── spatial operations (the capabilities) ────────────────────────────
+    class SpatialOp(str, Enum):
+        POINT_IN_POLYGON = "POINT_IN_POLYGON"
+        INTERSECTS = "INTERSECTS"
+        WITHIN = "WITHIN"
+        CONTAINS = "CONTAINS"
+        OVERLAPS = "OVERLAPS"
+        TOUCHES = "TOUCHES"
+        DISTANCE = "DISTANCE"
+        NEAREST = "NEAREST"
+        BUFFER = "BUFFER"
+        CENTROID = "CENTROID"
+        SPATIAL_JOIN = "SPATIAL_JOIN"
+        BBOX_QUERY = "BBOX_QUERY"
+        REPROJECT = "REPROJECT"
+        AREA = "AREA"
 
-class SpatialOp(str, Enum):
-    POINT_IN_POLYGON = "POINT_IN_POLYGON"
-    INTERSECTS = "INTERSECTS"
-    WITHIN = "WITHIN"
-    CONTAINS = "CONTAINS"
-    OVERLAPS = "OVERLAPS"
-    TOUCHES = "TOUCHES"
-    DISTANCE = "DISTANCE"
-    NEAREST = "NEAREST"
-    BUFFER = "BUFFER"
-    CENTROID = "CENTROID"
-    SPATIAL_JOIN = "SPATIAL_JOIN"
-    BBOX_QUERY = "BBOX_QUERY"
-    REPROJECT = "REPROJECT"
-    AREA = "AREA"
+    def geometry_hash(rings: list[Ring], crs: str) -> str:
+        """Canonical geometry identity — byte-identical to runtime_contracts.protocol.geospatial."""
+        norm = [[[round(float(x), GEOMETRY_PRECISION), round(float(y), GEOMETRY_PRECISION)]
+                 for x, y in ring] for ring in rings]
+        payload = json.dumps({"crs": crs, "rings": norm}, sort_keys=True, separators=(",", ":"))
+        return "geo:" + hashlib.blake2b(payload.encode(), digest_size=16).hexdigest()
 
-
-# ──────────────────────────── typed spatial evidence ────────────────────────────
-
-def geometry_hash(rings: list[Ring], crs: str) -> str:
-    """Canonical, stable identity for a geometry — rounded coords + CRS, hashed. Same boundary in the same
-    CRS → same id across providers, so parcel identity is not provider-specific."""
-    # normalise to float so an int coord (0) and its float twin (0.0) hash identically
-    norm = [[[round(float(x), 7), round(float(y), 7)] for x, y in ring] for ring in rings]
-    payload = json.dumps({"crs": crs, "rings": norm}, sort_keys=True, separators=(",", ":"))
-    return "geo:" + hashlib.blake2b(payload.encode(), digest_size=16).hexdigest()
-
-
-@dataclass(frozen=True)
-class GeoRef:
-    """A typed geospatial reference carried with evidence (plan §2). Extends, not replaces, EvidenceRef."""
-    geometry_type: str                         # "Polygon" | "Point" | "MultiPolygon"
-    geometry_hash: str                         # canonical hashable identity (from geometry_hash())
-    crs: str                                   # explicit CRS/SRID, e.g. "EPSG:4326"
-    bbox: tuple[float, float, float, float]    # (minx, miny, maxx, maxy)
-    centroid: Coord
-    jurisdiction: str = ""
-    spatial_resolution: float | None = None
-    horizontal_accuracy: float | None = None
-    valid_time: str = ""                       # world-time validity (ISO); "" = -inf
-    observed_at: str = ""                      # when observed/recorded (transaction time)
-    source: str = ""
-    source_version: str = ""
+    @dataclass(frozen=True)
+    class GeoRef:
+        """A typed geospatial reference carried with evidence. Extends, not replaces, EvidenceRef."""
+        geometry_type: str
+        geometry_hash: str
+        crs: str
+        bbox: tuple[float, float, float, float]
+        centroid: Coord
+        jurisdiction: str = ""
+        spatial_resolution: float | None = None
+        horizontal_accuracy: float | None = None
+        valid_time: str = ""
+        observed_at: str = ""
+        source: str = ""
+        source_version: str = ""
 
 
 # ──────────────────────────── zoning / parcel domain (plan §8-10) ────────────────────────────

--- a/context_runtime/geospatial/engine.py
+++ b/context_runtime/geospatial/engine.py
@@ -1,0 +1,148 @@
+"""CPU-authoritative deterministic spatial engine (plan §2, §4) — the reference implementation.
+
+Pure-Python, exact, dependency-free geometry: point-in-polygon (ray casting), polygon intersection (bbox
+prefilter + vertex containment + edge crossing), area (shoelace), distance, centroid, bbox, spatial join.
+This is the authoritative path — an optional shapely/PostGIS/GPU backend may be selected for speed later,
+but must return the same relations (the accelerator changes latency, not the answer).
+
+Deterministic-first rules the plan insists on:
+  * **No silent CRS mismatch.** Binary operations require operands in the same CRS; otherwise a CrsMismatch
+    is raised so the planner inserts an explicit, auditable REPROJECT node (a blocking-SLO invariant).
+  * Geometry is assumed to be in a **planar CRS (metres/feet)** for area/distance; geographic lon/lat must be
+    reprojected first (the REPROJECT capability). Point-in-polygon is CRS-agnostic (topological).
+"""
+from __future__ import annotations
+
+from .contracts import Coord, Ring
+
+
+class CrsMismatch(ValueError):
+    """A binary spatial op was asked to combine operands in different CRSs — never done silently."""
+
+
+def require_same_crs(a_crs: str, b_crs: str) -> None:
+    if a_crs != b_crs:
+        raise CrsMismatch(f"CRS mismatch: {a_crs} vs {b_crs} — insert a REPROJECT node before this op")
+
+
+# ──────────────────────────── primitives ────────────────────────────
+
+def bbox(ring: Ring) -> tuple[float, float, float, float]:
+    xs = [x for x, _ in ring]
+    ys = [y for _, y in ring]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def bbox_intersects(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> bool:
+    return not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1])
+
+
+def signed_area(ring: Ring) -> float:
+    """Shoelace signed area (planar CRS units²). Positive = counter-clockwise."""
+    s = 0.0
+    n = len(ring)
+    for i in range(n):
+        x1, y1 = ring[i]
+        x2, y2 = ring[(i + 1) % n]
+        s += x1 * y2 - x2 * y1
+    return s / 2.0
+
+
+def area(ring: Ring) -> float:
+    return abs(signed_area(ring))
+
+
+def centroid(ring: Ring) -> Coord:
+    """Polygon centroid (planar). Falls back to vertex mean for degenerate/zero-area rings."""
+    a = signed_area(ring)
+    if abs(a) < 1e-12:
+        n = len(ring) or 1
+        return (sum(x for x, _ in ring) / n, sum(y for _, y in ring) / n)
+    cx = cy = 0.0
+    n = len(ring)
+    for i in range(n):
+        x1, y1 = ring[i]
+        x2, y2 = ring[(i + 1) % n]
+        cross = x1 * y2 - x2 * y1
+        cx += (x1 + x2) * cross
+        cy += (y1 + y2) * cross
+    return (cx / (6 * a), cy / (6 * a))
+
+
+def distance(a: Coord, b: Coord) -> float:
+    """Euclidean distance in planar CRS units (metres/feet). Geographic coords must be reprojected first."""
+    return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+
+
+# ──────────────────────────── point-in-polygon (ray casting; CRS-agnostic) ────────────────────────────
+
+def point_in_ring(pt: Coord, ring: Ring) -> bool:
+    """True if pt is strictly inside or on the boundary of the ring (even-odd ray casting)."""
+    x, y = pt
+    inside = False
+    n = len(ring)
+    for i in range(n):
+        x1, y1 = ring[i]
+        x2, y2 = ring[(i + 1) % n]
+        # boundary check (on an edge counts as inside — deterministic tie-break)
+        if min(y1, y2) <= y <= max(y1, y2) and min(x1, x2) - 1e-12 <= x <= max(x1, x2) + 1e-12:
+            if abs((x2 - x1) * (y - y1) - (x - x1) * (y2 - y1)) < 1e-9:
+                return True
+        if (y1 > y) != (y2 > y):
+            xint = (x2 - x1) * (y - y1) / (y2 - y1) + x1
+            if x < xint:
+                inside = not inside
+    return inside
+
+
+def point_in_polygon(pt: Coord, outer: Ring, holes: list[Ring] | None = None) -> bool:
+    if not point_in_ring(pt, outer):
+        return False
+    for h in (holes or []):
+        if point_in_ring(pt, h):
+            return False
+    return True
+
+
+# ──────────────────────────── segment / polygon intersection ────────────────────────────
+
+def _seg_cross(p1: Coord, p2: Coord, p3: Coord, p4: Coord) -> bool:
+    def orient(a, b, c):
+        v = (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+        return (v > 1e-12) - (v < -1e-12)
+    d1, d2 = orient(p3, p4, p1), orient(p3, p4, p2)
+    d3, d4 = orient(p1, p2, p3), orient(p1, p2, p4)
+    return d1 != d2 and d3 != d4
+
+
+def polygons_intersect(a: Ring, b: Ring) -> bool:
+    """Deterministic polygon-polygon intersection: bbox prefilter, then containment either way, then any
+    edge crossing. Sufficient for parcel↔zoning overlap on simple (non-self-intersecting) rings."""
+    if not bbox_intersects(bbox(a), bbox(b)):
+        return False
+    if any(point_in_ring(p, b) for p in a) or any(point_in_ring(p, a) for p in b):
+        return True
+    na, nb = len(a), len(b)
+    for i in range(na):
+        for j in range(nb):
+            if _seg_cross(a[i], a[(i + 1) % na], b[j], b[(j + 1) % nb]):
+                return True
+    return False
+
+
+# ──────────────────────────── spatial join (the workhorse for zoning assignment) ────────────────────────────
+
+def spatial_join_by_centroid(parcels: list[tuple[str, Ring, str]],
+                             zones: list[tuple[str, Ring, str]]) -> dict[str, list[str]]:
+    """Assign each parcel to the zoning polygons whose area contains the parcel's centroid. Operands must
+    share a CRS (checked). Deterministic. parcels/zones are (id, ring, crs). Returns parcel_id -> [zone_id]."""
+    out: dict[str, list[str]] = {}
+    for pid, pring, pcrs in parcels:
+        c = centroid(pring)
+        hits = []
+        for zid, zring, zcrs in zones:
+            require_same_crs(pcrs, zcrs)
+            if point_in_polygon(c, zring):
+                hits.append(zid)
+        out[pid] = hits
+    return out

--- a/context_runtime/integrations/zoning_intelligence.py
+++ b/context_runtime/integrations/zoning_intelligence.py
@@ -1,0 +1,450 @@
+"""Zoning Intelligence × Context Runtime — the geospatial reference tenant (plan §6, §13-18).
+
+The decision point is **which evidence sources to acquire** before concluding what a parcel supports —
+commercial parcel/zoning providers (Regrid, ATTOM), the official municipal GIS, and the zoning
+ordinance text. The reward is *the correct land-use disposition at the cheapest sufficient evidence
+bundle* — the same fleet pattern as the other tenants, over the geospatial domain.
+
+What makes this tenant more than a bandit clone is the **deterministic-first, fail-safe resolver**
+(`resolve_disposition`): geometry and structured evidence are reconciled by the CPU spatial engine
+BEFORE any ordinance/LLM interpretation, and a parcel is only ever concluded ``PERMITTED`` when the
+gathered evidence is sufficient to confirm it. When sources disagree or the decisive source is absent,
+the resolver returns ``UNKNOWN`` rather than guess — so a single stale provider can never produce a
+"verified permitted" (the blocking SLO ``false-permitted = 0``, plan §16). Reconciliation (≥2 sources)
+is what converts an unsafe single-provider guess into a safe ``UNKNOWN``.
+
+Everything here is offline and deterministic: `build_reference_world()` is a fixture jurisdiction
+(Fulton County, GA; EPSG:2240 planar feet) with real parcel geometry, overlay polygons, and a hidden
+ground truth the providers observe with source-specific fidelity — exactly like the other tenants'
+simulated backends. Swap the providers for live Regrid/ATTOM/ArcGIS calls and nothing else changes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..geospatial.contracts import (
+    ConstraintType, GeoRef, LandUseConstraint, ParcelEntity, Ring, UseDisposition, geometry_hash,
+)
+from ..geospatial.engine import area, bbox, centroid, distance, point_in_polygon, polygons_intersect
+from ..runtime.runtime import ContextRuntime
+from ..types import Goal, Plan, Trace
+from .bandit import EpsilonGreedyBandit
+
+# ──────────────────────────── use ontology → evidence-difficulty bucket ────────────────────────────
+# Target uses this benchmark judges, grouped by the evidence tier that decides them (plan §9, §14).
+# Each bucket has ONE minimal-sufficient evidence bundle; the bandit learns it from outcomes.
+TARGET_USES: tuple[str, ...] = (
+    "RESIDENTIAL_SINGLE_FAMILY", "OFFICE", "RETAIL", "WAREHOUSE", "LIGHT_INDUSTRIAL", "DATA_CENTER",
+)
+USE_BUCKET: dict[str, str] = {
+    "RESIDENTIAL_SINGLE_FAMILY": "residential",   # base zoning decides → commercial consensus suffices
+    "OFFICE": "commercial", "RETAIL": "commercial",  # overlay-sensitive → needs official GIS
+    "WAREHOUSE": "industrial", "LIGHT_INDUSTRIAL": "industrial", "DATA_CENTER": "industrial",  # +ordinance
+}
+# Base zonings where a use is at least conditionally allowed (plan §9 mapping, with evidence).
+BASE_ALLOWS: dict[str, frozenset[str]] = {
+    "RESIDENTIAL_SINGLE_FAMILY": frozenset({"R-1"}),
+    "OFFICE": frozenset({"C-2"}), "RETAIL": frozenset({"C-2"}),
+    "WAREHOUSE": frozenset({"M-1"}), "LIGHT_INDUSTRIAL": frozenset({"M-1"}), "DATA_CENTER": frozenset({"M-1"}),
+}
+# Uses whose permissibility can be flipped by an overlay district → require the authoritative GIS.
+OVERLAY_SENSITIVE: frozenset[str] = frozenset({"OFFICE", "RETAIL", "WAREHOUSE", "LIGHT_INDUSTRIAL", "DATA_CENTER"})
+# Uses whose final disposition (permitted vs conditional vs special-exception) lives in ordinance text.
+CONDITIONAL_USES: frozenset[str] = frozenset({"WAREHOUSE", "LIGHT_INDUSTRIAL", "DATA_CENTER"})
+RESTRICTIVE_OVERLAYS: frozenset[str] = frozenset({"FLOOD", "HISTORIC"})
+# Deterministic structured constraint: minimum lot area (planar ft²) — checked BEFORE any interpretation.
+MIN_LOT_AREA: dict[str, float] = {"DATA_CENTER": 87120.0}   # 2 acres; small lots are prohibited outright
+
+
+def zoning_bucket(use: str) -> str:
+    """The bandit context key: the evidence-difficulty class of a target use (plan §14)."""
+    return USE_BUCKET.get(use, "commercial")
+
+
+# ──────────────────────────── the fixture jurisdiction (ground truth) ────────────────────────────
+
+
+@dataclass
+class ZoningWorld:
+    """Ground truth for the reference jurisdiction. Providers observe this with source-specific fidelity;
+    the LLM/derived layer is never treated as truth (plan §15). Offline and fully deterministic."""
+    crs: str
+    parcels: dict[str, ParcelEntity]                     # parcel_id → canonical entity (geometry, lot_area)
+    rings: dict[str, Ring]                               # parcel_id → its outer ring (for spatial ops)
+    base_truth: dict[str, str]                           # parcel_id → true base zoning
+    regrid_view: dict[str, str]                          # parcel_id → Regrid's (possibly stale) base zoning
+    overlays: list[tuple[str, Ring]]                     # (overlay_kind, ring) districts, e.g. ("FLOOD", ring)
+    ordinance_det: dict[tuple[str, str], UseDisposition]  # (parcel_id, use) → authoritative conditional call
+
+
+def _parcel(pid: str, x0: float, y0: float, size: float, base: str, crs: str) -> tuple[ParcelEntity, Ring]:
+    ring: Ring = [(x0, y0), (x0 + size, y0), (x0 + size, y0 + size), (x0, y0 + size)]
+    gh = geometry_hash([ring], crs)
+    ref = GeoRef(geometry_type="Polygon", geometry_hash=gh, crs=crs, bbox=bbox(ring),
+                 centroid=centroid(ring), jurisdiction="Fulton County, GA", source="fixture")
+    ent = ParcelEntity(parcel_id=gh, geometry_ref=ref, apn=pid, jurisdiction="Fulton County, GA",
+                       lot_area=area(ring), zoning_districts=[base])
+    return ent, ring
+
+
+def build_reference_world(crs: str = "EPSG:2240") -> tuple[ZoningWorld, dict[str, str]]:
+    """A small, honest jurisdiction exercising every arm's decisive evidence tier. Returns the world and
+    an ``apn → parcel_id`` index (callers key parcels by the human-readable APN)."""
+    specs = [
+        # apn,  x0,   y0,  size, true_base, regrid_stale_to(None=accurate)
+        ("R-100", 0, 0, 200, "R-1", None),            # residential, clean → commercial consensus suffices
+        ("R-101", 300, 0, 200, "R-1", None),
+        ("R-102", 600, 0, 200, "C-2", "R-1"),         # STALE: Regrid still says R-1; truth is C-2 → false-permit trap
+        ("O-200", 0, 400, 200, "C-2", None),          # office/retail, overlay-sensitive → needs GIS
+        ("O-201", 300, 400, 200, "C-2", None),        # sits under a FLOOD overlay → GIS flips it PROHIBITED
+        ("W-300", 0, 800, 300, "M-1", None),          # warehouse/industrial → needs GIS + ordinance
+        ("W-301", 400, 800, 300, "M-1", None),        # HISTORIC overlay → GIS PROHIBITED
+        ("D-400", 900, 800, 100, "M-1", None),        # data-center on a small lot → deterministic PROHIBITED
+        ("D-401", 900, 1100, 400, "M-1", None),       # data-center, big lot, conditional → ordinance decides
+    ]
+    parcels: dict[str, ParcelEntity] = {}
+    rings: dict[str, Ring] = {}
+    base_truth: dict[str, str] = {}
+    regrid_view: dict[str, str] = {}
+    apn_index: dict[str, str] = {}
+    for apn, x0, y0, size, base, stale in specs:
+        ent, ring = _parcel(apn, x0, y0, size, base, crs)
+        pid = ent.parcel_id
+        parcels[pid] = ent
+        rings[pid] = ring
+        base_truth[pid] = base
+        regrid_view[pid] = stale or base
+        apn_index[apn] = pid
+    # Overlay districts (real polygons; membership is a deterministic spatial intersect).
+    overlays: list[tuple[str, Ring]] = [
+        ("FLOOD", [(250, 350), (700, 350), (700, 700), (250, 700)]),      # covers O-201
+        ("HISTORIC", [(380, 780), (720, 780), (720, 1120), (380, 1120)]),  # covers W-301
+    ]
+    # Authoritative ordinance determinations for conditional (industrial) uses.
+    ordinance_det: dict[tuple[str, str], UseDisposition] = {
+        (apn_index["W-300"], "WAREHOUSE"): UseDisposition.PERMITTED,
+        (apn_index["W-300"], "LIGHT_INDUSTRIAL"): UseDisposition.CONDITIONAL,
+        (apn_index["D-401"], "DATA_CENTER"): UseDisposition.CONDITIONAL,
+        (apn_index["D-401"], "LIGHT_INDUSTRIAL"): UseDisposition.PERMITTED,
+    }
+    world = ZoningWorld(crs=crs, parcels=parcels, rings=rings, base_truth=base_truth,
+                        regrid_view=regrid_view, overlays=overlays, ordinance_det=ordinance_det)
+    return world, apn_index
+
+
+# ──────────────────────────── providers (observe the world with source-specific fidelity) ──────────
+
+
+class Provider:
+    """Read-only evidence source. Live subclasses would hit Regrid/ATTOM/ArcGIS; here they read the
+    fixture world. Each exposes what it can actually see — Regrid/ATTOM see only base zoning (and Regrid
+    can be stale); the municipal GIS sees base + overlays authoritatively; the ordinance resolves the
+    conditional-use call. Provider disagreement is preserved, never flattened (plan §8)."""
+
+    name = "provider"
+    cost = 1.0
+
+    def __init__(self, world: ZoningWorld):
+        self.world = world
+
+
+class RegridProvider(Provider):
+    name, cost = "regrid", 1.0
+
+    def observe(self, pid: str) -> dict:
+        base = self.world.regrid_view.get(pid, self.world.base_truth[pid])
+        return {"source": "regrid", "base_zoning": base, "stale": base != self.world.base_truth[pid]}
+
+
+class AttomProvider(Provider):
+    name, cost = "attom", 1.0     # independent commercial source — disagreement with Regrid catches staleness
+
+    def observe(self, pid: str) -> dict:
+        return {"source": "attom", "base_zoning": self.world.base_truth[pid]}
+
+
+class MunicipalGisProvider(Provider):
+    name, cost = "municipal_gis", 2.0   # official; authoritative base + overlays (deterministic spatial join)
+
+    def observe(self, pid: str) -> dict:
+        ring = self.world.rings[pid]
+        hits = [kind for kind, oring in self.world.overlays if polygons_intersect(ring, oring)]
+        return {"source": "municipal_gis", "base_zoning": self.world.base_truth[pid], "overlays": tuple(hits)}
+
+
+class OrdinanceProvider(Provider):
+    name, cost = "ordinance", 4.0   # expensive: official ordinance text + interpretation for conditional uses
+
+    def observe(self, pid: str, use: str) -> dict:
+        det = self.world.ordinance_det.get((pid, use), UseDisposition.PERMITTED)
+        return {"source": "ordinance", "determination": det}
+
+
+def build_providers(world: ZoningWorld) -> dict[str, Provider]:
+    return {p.name: p for p in (RegridProvider(world), AttomProvider(world),
+                                MunicipalGisProvider(world), OrdinanceProvider(world))}
+
+
+# ──────────────────────────── the deterministic-first, fail-safe resolver (plan §4, §16) ──────────
+
+
+@dataclass(frozen=True)
+class Assessment:
+    parcel_id: str
+    use: str
+    disposition: UseDisposition
+    confidence: float
+    sources_used: tuple[str, ...]
+    reasons: tuple[str, ...]
+    constraints: tuple[LandUseConstraint, ...] = ()
+
+
+def resolve_disposition(world: ZoningWorld, providers: dict[str, Provider], pid: str, use: str,
+                        sources: tuple[str, ...]) -> Assessment:
+    """Reconcile the available evidence into a disposition. PERMITTED is emitted ONLY when the gathered
+    evidence is sufficient to confirm it; otherwise UNKNOWN. This is what makes false-permitted a
+    structural impossibility for reconciled bundles (plan §16 blocking SLO)."""
+    present = set(sources)
+    reasons: list[str] = []
+    parcel = world.parcels[pid]
+
+    # 1 ── deterministic structured constraint (geometry before interpretation).
+    min_area = MIN_LOT_AREA.get(use)
+    if min_area is not None and parcel.lot_area is not None and parcel.lot_area < min_area:
+        c = LandUseConstraint(type=ConstraintType.MIN_LOT_AREA, value=min_area, unit="ft^2",
+                              operator=">=", source_evidence="deterministic:lot_area")
+        return Assessment(pid, use, UseDisposition.PROHIBITED, 1.0, sources,
+                          (f"lot_area {parcel.lot_area:.0f} < MIN_LOT_AREA {min_area:.0f}",), (c,))
+
+    # 2 ── base zoning: authoritative from GIS, else commercial consensus (reconciliation).
+    gis = providers["municipal_gis"].observe(pid) if "municipal_gis" in present else None
+    bases = {}
+    if "regrid" in present:
+        bases["regrid"] = providers["regrid"].observe(pid)["base_zoning"]
+    if "attom" in present:
+        bases["attom"] = providers["attom"].observe(pid)["base_zoning"]
+    if gis is not None:
+        base = gis["base_zoning"]
+        reasons.append(f"base={base} (official GIS)")
+    elif "regrid" in bases and "attom" in bases:
+        if bases["regrid"] != bases["attom"]:
+            reasons.append(f"provider disagreement regrid={bases['regrid']} attom={bases['attom']}")
+            return Assessment(pid, use, UseDisposition.UNKNOWN, 0.4, sources, tuple(reasons))
+        base = bases["attom"]
+        reasons.append(f"base={base} (commercial consensus)")
+    elif bases:
+        base = next(iter(bases.values()))
+        reasons.append(f"base={base} (single commercial source, unreconciled)")
+    else:
+        return Assessment(pid, use, UseDisposition.UNKNOWN, 0.2, sources, ("no base-zoning evidence",))
+
+    # 3 ── base compatibility.
+    if base not in BASE_ALLOWS.get(use, frozenset()):
+        return Assessment(pid, use, UseDisposition.PROHIBITED, 0.9, sources,
+                          tuple(reasons) + (f"{use} not allowed in {base}",))
+
+    # 4 ── overlay sensitivity: needs the authoritative GIS to rule out a restrictive overlay.
+    if use in OVERLAY_SENSITIVE:
+        if gis is None:
+            reasons.append("overlay-sensitive use, no official GIS → cannot confirm no overlay")
+            return Assessment(pid, use, UseDisposition.UNKNOWN, 0.5, sources, tuple(reasons))
+        restrictive = [o for o in gis["overlays"] if o in RESTRICTIVE_OVERLAYS]
+        if restrictive:
+            return Assessment(pid, use, UseDisposition.PROHIBITED, 0.95, sources,
+                              tuple(reasons) + (f"restrictive overlay {restrictive}",))
+
+    # 5 ── conditional use: the final call lives in the ordinance text.
+    if use in CONDITIONAL_USES:
+        if "ordinance" not in present:
+            reasons.append("conditional use, no ordinance → cannot confirm disposition")
+            return Assessment(pid, use, UseDisposition.UNKNOWN, 0.5, sources, tuple(reasons))
+        det = providers["ordinance"].observe(pid, use)["determination"]
+        return Assessment(pid, use, det, 0.9, sources, tuple(reasons) + (f"ordinance→{det.value}",))
+
+    return Assessment(pid, use, UseDisposition.PERMITTED, 0.85, sources, tuple(reasons) + ("base permits",))
+
+
+def gold_disposition(world: ZoningWorld, providers: dict[str, Provider], pid: str, use: str) -> UseDisposition:
+    """The reference answer: resolve with the full authoritative evidence set (all sources)."""
+    return resolve_disposition(world, providers, pid, use, ("regrid", "attom", "municipal_gis", "ordinance")).disposition
+
+
+# ──────────────────────────── the bandit arm + reward (plan §14) ────────────────────────────
+
+
+@dataclass(frozen=True)
+class EvidencePlan:
+    """A bandit arm: which evidence sources to acquire for an assessment. Fewer = cheaper."""
+    sources: tuple[str, ...]
+
+    @property
+    def key(self) -> str:
+        return "+".join(self.sources)   # sources are declared in escalation order; keep it
+
+    def cost_units(self, providers: dict[str, Provider]) -> float:
+        return sum(providers[s].cost for s in self.sources)
+
+
+# Escalating evidence bundles: single-provider → commercial consensus → +official GIS → +ordinance.
+DEFAULT_ARMS: tuple[EvidencePlan, ...] = (
+    EvidencePlan(("regrid",)),
+    EvidencePlan(("regrid", "attom")),
+    EvidencePlan(("regrid", "attom", "municipal_gis")),
+    EvidencePlan(("regrid", "attom", "municipal_gis", "ordinance")),
+)
+_MAX_COST = 8.0   # regrid1 + attom1 + gis2 + ordinance4 — the reward-normalizing reference
+COST_LAMBDA = 0.15
+FALSE_PERMIT_PENALTY = 1.0   # a "verified permitted" that is actually prohibited is worse than a miss
+
+
+def reward_zoning(*, correct: bool, false_permitted: bool, cost_units: float) -> float:
+    """Correct disposition at the cheapest sufficient evidence — with a hard penalty for the blocking-SLO
+    violation (false-permitted). UNKNOWN when unsure is a plain miss (0.0), never penalized like a lie."""
+    if false_permitted:
+        return -FALSE_PERMIT_PENALTY
+    if not correct:
+        return 0.0
+    return round(1.0 - COST_LAMBDA * (cost_units / _MAX_COST), 4)
+
+
+def _zoning_bandit(epsilon: float = 0.12, arms: tuple[EvidencePlan, ...] = DEFAULT_ARMS) -> EpsilonGreedyBandit:
+    return EpsilonGreedyBandit(arms, epsilon=epsilon)
+
+
+# ──────────────────────────── the tenant ────────────────────────────
+
+
+@dataclass
+class _Pending:
+    plan: Plan
+    arm: EvidencePlan
+    bucket: str
+    assessment: Assessment
+
+
+class ZoningIntelligenceTenant:
+    """Context Runtime plans zoning intelligence: pick the cheapest evidence bundle that resolves a
+    parcel/use question, reconcile the evidence deterministically, conclude a disposition (or abstain to
+    UNKNOWN), and learn — per use-difficulty bucket — the minimal sufficient bundle from outcomes."""
+
+    def __init__(self, world: ZoningWorld | None = None, runtime: ContextRuntime | None = None,
+                 bandit: EpsilonGreedyBandit | None = None, arms: tuple[EvidencePlan, ...] = DEFAULT_ARMS):
+        if world is None:
+            world, _ = build_reference_world()
+        self.world = world
+        self.providers = build_providers(world)
+        self.runtime = runtime or ContextRuntime.default([])
+        self.bandit = bandit or _zoning_bandit(arms=arms)
+        self._pending: dict[str, _Pending] = {}
+
+    # ── parcel-first: "what can I build/operate on this parcel?" ──
+    def assess(self, query_id: str, parcel_id: str, use: str) -> Assessment:
+        bucket = zoning_bucket(use)
+        plan = self.runtime.plan(Goal(text=f"{use} on {parcel_id}"))
+        arm = self.bandit.select(bucket)
+        a = resolve_disposition(self.world, self.providers, parcel_id, use, arm.sources)
+        self._pending[query_id] = _Pending(plan, arm, bucket, a)
+        return a
+
+    def record(self, query_id: str, gold: UseDisposition) -> float:
+        """Feed back the reference disposition. Correct = matched gold; false-permitted = concluded
+        PERMITTED where gold is PROHIBITED (the SLO violation). Updates the bandit + cost model."""
+        p = self._pending.pop(query_id, None)
+        if p is None:
+            return 0.0
+        correct = p.assessment.disposition == gold
+        false_permitted = p.assessment.disposition == UseDisposition.PERMITTED and gold == UseDisposition.PROHIBITED
+        reward = reward_zoning(correct=correct, false_permitted=false_permitted,
+                               cost_units=p.arm.cost_units(self.providers))
+        self.bandit.update(p.bucket, p.arm, reward)
+        trace = Trace(plan_id=p.plan.id, goal_text=f"{p.assessment.use} on {p.assessment.parcel_id}",
+                      actual_cost_usd=p.arm.cost_units(self.providers) * 0.01,
+                      verification_passed=correct)
+        self.runtime.estimator.observe(p.plan, trace)
+        return reward
+
+    # ── use-first: "find parcels compatible with this use in an area" (plan §6, §12) ──
+    def search(self, use: str, *, center: tuple[float, float], radius: float,
+               min_lot_area: float = 0.0) -> list[Assessment]:
+        """A governed candidate set: deterministic spatial filter (within radius + lot area) THEN the
+        learned evidence bundle per candidate. Only confidently-PERMITTED parcels are returned; UNKNOWN
+        and PROHIBITED are withheld (they surface in EXPLAIN as REQUIRE_REVIEW / rejected)."""
+        bucket = zoning_bucket(use)
+        arm = self.bandit.select(bucket)
+        out: list[Assessment] = []
+        for pid, ent in self.world.parcels.items():
+            if ent.lot_area is not None and ent.lot_area < min_lot_area:
+                continue
+            if distance(ent.geometry_ref.centroid, center) > radius:   # deterministic spatial prefilter
+                continue
+            a = resolve_disposition(self.world, self.providers, pid, use, arm.sources)
+            if a.disposition == UseDisposition.PERMITTED:
+                out.append(a)
+        return out
+
+    def explain(self, query_id: str) -> dict:
+        """Per-assessment EXPLAIN: the selected bundle, its expected value, and every arm scored — plus
+        the evidence reasons that produced the conclusion (the essential UI feature, plan §21)."""
+        p = self._pending.get(query_id)
+        bucket = p.bucket if p else "commercial"
+        scores = []
+        for arm in DEFAULT_ARMS:
+            n, val = self.bandit.value(bucket, arm.key)
+            scores.append({"arm": arm.key, "n": n, "value": round(val, 4),
+                           "cost_units": arm.cost_units(self.providers)})
+        exp = {"query": query_id, "bucket": bucket,
+               "scores": sorted(scores, key=lambda s: s["value"], reverse=True)}
+        if p is not None:
+            exp["selected"] = p.arm.key
+            exp["disposition"] = p.assessment.disposition.value
+            exp["confidence"] = p.assessment.confidence
+            exp["reasons"] = list(p.assessment.reasons)
+        return exp
+
+    def policy(self) -> dict[str, str]:
+        return self.bandit.policy()
+
+
+# ──────────────────────────── incremental evidence change (plan §17, Phase 8) ────────────────────────────
+
+
+def affected_conclusions(world: ZoningWorld, changed_parcel_ids: set[str],
+                         changed_overlay_rings: list[Ring] | None = None) -> set[str]:
+    """Dependency-scoped recomputation set: the parcels whose conclusions an EvidenceChange invalidates.
+    A parcel is affected if it changed directly, OR if its geometry intersects a changed overlay polygon.
+    Everything else stays valid — the geospatial analogue of incremental Discovery (plan §17)."""
+    affected = set(changed_parcel_ids)
+    for ring in (changed_overlay_rings or []):
+        for pid, pring in world.rings.items():
+            if polygons_intersect(pring, ring):
+                affected.add(pid)
+    return affected
+
+
+# ──────────────────────────── population governance (plan §18, Phase 9) ────────────────────────────
+
+
+class PopulationGovernor:
+    """Detects a systematic quality shift across the parcel population that individual records hide — e.g.
+    a provider/classifier that starts mapping CONDITIONAL → PERMITTED. Compares a recent window's
+    downgrade rate against a healthy baseline; a jump past the threshold yields REQUIRE_REVIEW for the
+    whole series, not just one parcel (plan §18)."""
+
+    def __init__(self, baseline_rate: float = 0.0, threshold: float = 0.25, window: int = 20):
+        self.baseline_rate = baseline_rate
+        self.threshold = threshold
+        self.window = window
+        self._recent: dict[str, list[int]] = {}
+
+    def observe(self, series_id: str, downgraded: bool) -> None:
+        buf = self._recent.setdefault(series_id, [])
+        buf.append(1 if downgraded else 0)
+        if len(buf) > self.window:
+            del buf[0]
+
+    def recent_rate(self, series_id: str) -> float:
+        buf = self._recent.get(series_id, [])
+        return sum(buf) / len(buf) if buf else 0.0
+
+    def review_required(self, series_id: str) -> bool:
+        return self.recent_rate(series_id) - self.baseline_rate > self.threshold

--- a/examples/data/HARVEST.md
+++ b/examples/data/HARVEST.md
@@ -1,0 +1,20 @@
+# Harvested zoning data — provenance
+
+These fixtures are **real** parcels/districts harvested from OFFICIAL keyless sources by the
+`zoning-sources-mcp` server (US Census/FCC jurisdiction resolution → ArcGIS Hub discovery → ArcGIS REST
+query against each jurisdiction's own published zoning layer). No API-provider data; no keys.
+
+- `harvested_brisbane_ca.json` — 3 parcels from Brisbane, CA's published zoning layer.
+- `harvested_us_sample.json` — a 32-parcel, cross-country sample (one parcel per distinct dataset:
+  Phoenix, Tucson, LA County, San Diego, SF, Oakland, Denver, Miami, Las Vegas, Charlotte, Raleigh,
+  Cincinnati, Columbus, Cleveland, Philadelphia, San Antonio, Salt Lake, Soldotna, …).
+
+Drawn from the full nationwide sweep (kept off-repo for size):
+
+> **DONE: 149,624 districts from 4,562 official ArcGIS services, 16,711 distinct zoning codes,
+> 1,880 datasets** — the ArcGIS Hub `zoning` index swept to end-of-index (page 103).
+
+Each record carries the canonical `geometry_hash` id (`parcel_id`), CRS, bbox/centroid, the real zoning
+code, and — where published — a link to the district's ordinance page. `examples/zoning_real_world.py
+nationwide` runs the deterministic-first, fail-safe tenant over the sample: **false-permits = 0**, with
+honest `UNKNOWN` abstention wherever the answer depends on an ordinance use-table we have not parsed.

--- a/examples/data/harvested_brisbane_ca.json
+++ b/examples/data/harvested_brisbane_ca.json
@@ -1,0 +1,104 @@
+[
+  {
+    "parcel_id": "geo:72e3659d569820abb75e2af56f2c5574",
+    "crs": "EPSG:4326",
+    "geometry_type": "MultiPolygon",
+    "bbox": [
+      -122.40997549679,
+      37.6771392211434,
+      -122.396739844052,
+      37.6865635558845
+    ],
+    "centroid": [
+      -122.40121542874883,
+      37.68110430452543
+    ],
+    "apn": "",
+    "zoning_code": "R-1",
+    "jurisdiction": "Brisbane, CA",
+    "source_url": "https://services9.arcgis.com/UGpGSV1ugL0pHSgX/arcgis/rest/services/Zoning_Districts_NAD83_20251110/FeatureServer/3",
+    "ordinance_url": "https://www.brisbaneca.org/cd/page/r-1-residential-district",
+    "attributes": {
+      "FID": 9,
+      "FID_": 0,
+      "Descriptio": "Residential District",
+      "Abbreviati": "R-1",
+      "Hyperlink": "<a href=\"https://www.brisbaneca.org/cd/page/r-1-residential-district\" target=\"_top\">R-1 RESIDENTIAL DISTRICT</a>",
+      "Shape_Leng": 20585.7377594,
+      "Shape__Are": 974144.664542,
+      "Shape__Len": 7936.87359478,
+      "GlobalID": "{D933797A-63F5-4161-AD4A-65614165D343}",
+      "Shape__Area": 6555480.564453125,
+      "Shape__Length": 20585.737759332977,
+      "GlobalID_2": "01120069-b17e-4080-9cf8-bd80a3304e53"
+    }
+  },
+  {
+    "parcel_id": "geo:5e60b9289cee6525e84ac4e8ab0a9b7b",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -122.408054088406,
+      37.6732192312766,
+      -122.391499877695,
+      37.6847835974638
+    ],
+    "centroid": [
+      -122.39951946824424,
+      37.67911397291675
+    ],
+    "apn": "",
+    "zoning_code": "R-BA",
+    "jurisdiction": "Brisbane, CA",
+    "source_url": "https://services9.arcgis.com/UGpGSV1ugL0pHSgX/arcgis/rest/services/Zoning_Districts_NAD83_20251110/FeatureServer/3",
+    "ordinance_url": "https://www.brisbaneca.org/cd/page/r-ba-brisbane-acres-residential-district",
+    "attributes": {
+      "FID": 6,
+      "FID_": 0,
+      "Descriptio": "Brisbane Acres Residential District",
+      "Abbreviati": "R-BA",
+      "Hyperlink": "<a href=\"https://www.brisbaneca.org/cd/page/r-ba-brisbane-acres-residential-district\" target=\"_top\">R-BA BRISBANE ACRES RESIDENTIAL DISTRICT</a>",
+      "Shape_Leng": 18745.9545513,
+      "Shape__Are": 886107.046811,
+      "Shape__Len": 7226.14218794,
+      "GlobalID": "{0FBA853A-0B73-452B-91DE-5F18A5CF06B1}",
+      "Shape__Area": 5963731.478515625,
+      "Shape__Length": 18745.95455137053,
+      "GlobalID_2": "2966a6ff-e379-4970-be61-53c0016adf23"
+    }
+  },
+  {
+    "parcel_id": "geo:14fca2b3ed232e678634e03ec6e26721",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -122.408275749587,
+      37.6834173514796,
+      -122.39115627462,
+      37.7084130085327
+    ],
+    "centroid": [
+      -122.40214726922308,
+      37.69606446978696
+    ],
+    "apn": "",
+    "zoning_code": "C-1",
+    "jurisdiction": "Brisbane, CA",
+    "source_url": "https://services9.arcgis.com/UGpGSV1ugL0pHSgX/arcgis/rest/services/Zoning_Districts_NAD83_20251110/FeatureServer/3",
+    "ordinance_url": "https://www.brisbaneca.org/cd/page/c-1-commercial-mixed-use-district",
+    "attributes": {
+      "FID": 20,
+      "FID_": 0,
+      "Descriptio": "Commercial Mixed-Use District",
+      "Abbreviati": "C-1",
+      "Hyperlink": "<a href=\"https://www.brisbaneca.org/cd/page/c-1-commercial-mixed-use-district\" target=\"_top\">C/P-U NORTHWEST BAYSHORE COMMERCIAL/PUBLIC UTILITIES DISTRICT</a>",
+      "Shape_Leng": 26764.4001461,
+      "Shape__Are": 3656461.13856,
+      "Shape__Len": 10326.9896707,
+      "GlobalID": "{8FADFD5C-A5CE-4C85-BB21-0105BDA8D8FF}",
+      "Shape__Area": 24595615.0859375,
+      "Shape__Length": 26764.400145916617,
+      "GlobalID_2": "50c4ea42-d352-4ef9-9b8c-7337c81102e4"
+    }
+  }
+]

--- a/examples/data/harvested_us_sample.json
+++ b/examples/data/harvested_us_sample.json
@@ -1,0 +1,674 @@
+[
+  {
+    "parcel_id": "geo:c2b34427fb375214e06cb08e4e60aa2f",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -112.05407972079,
+      33.5074013583273,
+      -112.049712149907,
+      33.5085440186763
+    ],
+    "centroid": [
+      -112.05153236952849,
+      33.50781043890153
+    ],
+    "apn": "",
+    "zoning_code": "C-2",
+    "jurisdiction": "Zoning Districts of Phoenix, Arizona",
+    "dataset": "Zoning Districts of Phoenix, Arizona",
+    "source_url": "https://services6.arcgis.com/u2Q4oAfciDZpDAD8/arcgis/rest/services/Zoning_PhoenixAZ/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:503e28638400f2385027a0c84587cb89",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -112.004212783897,
+      33.4822430275962,
+      -112.003114820393,
+      33.4848633530091
+    ],
+    "centroid": [
+      -112.00349351783005,
+      33.48372481103293
+    ],
+    "apn": "",
+    "zoning_code": "R-4",
+    "jurisdiction": "Phoenix Zoning",
+    "dataset": "Phoenix Zoning",
+    "source_url": "https://services1.arcgis.com/Ezk9fcjSUkeadg6u/arcgis/rest/services/Phoenix_Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:3507038d42a2a07634d4cbf58eeb3b42",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -110.97617382912071,
+      32.206774512151675,
+      -110.97544720830021,
+      32.20742142421647
+    ],
+    "centroid": [
+      -110.97562652168736,
+      32.207168372383904
+    ],
+    "apn": "",
+    "zoning_code": "C-3",
+    "jurisdiction": "Zoning - Tucson - Open Data",
+    "dataset": "Zoning - Tucson - Open Data",
+    "source_url": "https://gis.tucsonaz.gov/arcgis/rest/services/PublicMaps/OpenData_PropertyPlanning/MapServer/19",
+    "ordinance_url": "https://codelibrary.amlegal.com/codes/tucson/latest/tucson_az_udc/0-0-0-2056"
+  },
+  {
+    "parcel_id": "geo:3241f599b7df89dbd6a2c45f287563ed",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -122.394627629925,
+      37.6747447786103,
+      -122.389619539096,
+      37.6826315833868
+    ],
+    "centroid": [
+      -122.39196813159664,
+      37.67825098669623
+    ],
+    "apn": "",
+    "zoning_code": "TC-2",
+    "jurisdiction": "Zoning Districts",
+    "dataset": "Zoning Districts",
+    "source_url": "https://services9.arcgis.com/UGpGSV1ugL0pHSgX/arcgis/rest/services/Zoning_Districts_NAD83_20251110/FeatureServer/3",
+    "ordinance_url": "https://www.brisbaneca.org/cd/page/tc-2-southeast-bayshore-trade-commercial-district"
+  },
+  {
+    "parcel_id": "geo:0abb6b6eabd061b2e39aecdad8a5e888",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -118.343670693527,
+      33.8775579976029,
+      -118.326695692823,
+      33.8872600766874
+    ],
+    "centroid": [
+      -118.33442260999912,
+      33.88234581140915
+    ],
+    "apn": "",
+    "zoning_code": "A-1",
+    "jurisdiction": "Zoning (Los Angeles County Unincorporated)",
+    "dataset": "Zoning (Los Angeles County Unincorporated)",
+    "source_url": "https://services2.arcgis.com/j80Jz20at6Bi0thr/arcgis/rest/services/Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:fc07165025b732fef0df38bf8156cc2d",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -117.129838402482,
+      33.0464268464181,
+      -117.129488004187,
+      33.0466530377507
+    ],
+    "centroid": [
+      -117.12969391914535,
+      33.04650359683874
+    ],
+    "apn": "",
+    "zoning_code": "AG-1-1",
+    "jurisdiction": "San Diego Zoning",
+    "dataset": "San Diego Zoning",
+    "source_url": "https://services1.arcgis.com/eGSDp8lpKe5izqVc/arcgis/rest/services/San_Diego_Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:583c3bee1bbc12cb3b6597c3fb1360e7",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -122.392141091338,
+      37.7324368513406,
+      -122.388685921403,
+      37.7394268830786
+    ],
+    "centroid": [
+      -122.39047021724119,
+      37.735546757989944
+    ],
+    "apn": "",
+    "zoning_code": "NCD",
+    "jurisdiction": "Bayview Hunters Point/Southeast San Francisco - Zoning",
+    "dataset": "Bayview Hunters Point/Southeast San Francisco - Zoning",
+    "source_url": "https://services3.arcgis.com/i2dkYWmb4wHvYPda/arcgis/rest/services/BVHP_San_Francisco_Zoning/FeatureServer/0",
+    "ordinance_url": "https://codelibrary.amlegal.com/codes/san_francisco/latest/sf_planning/0-0-0-25360#rid-0-0-0-62678"
+  },
+  {
+    "parcel_id": "geo:273146260547fe207247e58aedb58b9d",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -122.274616674234,
+      37.788327713849,
+      -122.266998009311,
+      37.7934790337588
+    ],
+    "centroid": [
+      -122.27204011583963,
+      37.791919452591145
+    ],
+    "apn": "",
+    "zoning_code": "Residential",
+    "jurisdiction": "West Oakland and Downtown Oakland Zoning",
+    "dataset": "West Oakland and Downtown Oakland Zoning",
+    "source_url": "https://services6.arcgis.com/HJzJQeO8rbTv2jiF/arcgis/rest/services/West_Oakland_and_Downtown_Oakland_Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:3cd9cb6a981165d6f0bad1721e57a2bd",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -122.226890215718,
+      37.7743784311914,
+      -122.2196580743,
+      37.7784642991023
+    ],
+    "centroid": [
+      -122.22309800457766,
+      37.77636479817354
+    ],
+    "apn": "",
+    "zoning_code": "CN-2",
+    "jurisdiction": "Oakland Business Zones CR",
+    "dataset": "Oakland Business Zones CR",
+    "source_url": "https://services.arcgis.com/9tC74aDHuml0x5Yz/arcgis/rest/services/Oakland_Business_Zones_CR/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:609a71d487eabe687faa7dbd2dac6eea",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -105.007232957,
+      39.763230519,
+      -105.006442104,
+      39.7644295480001
+    ],
+    "centroid": [
+      -105.00692858192858,
+      39.763942804285776
+    ],
+    "apn": "",
+    "zoning_code": "Former Chapter 59 Zone",
+    "jurisdiction": "Denver Zoning",
+    "dataset": "Denver Zoning",
+    "source_url": "https://services1.arcgis.com/PybKzo48QGbyiuCh/arcgis/rest/services/Denver_Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:e157a84617c4a4c0daf7d3098952be50",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -104.950055784656,
+      39.7428438087847,
+      -104.948258871151,
+      39.7437905492397
+    ],
+    "centroid": [
+      -104.94894381991068,
+      39.74307714639082
+    ],
+    "apn": "",
+    "zoning_code": "Two Unit  (TU)",
+    "jurisdiction": "CCD Zoning",
+    "dataset": "CCD Zoning",
+    "source_url": "https://services1.arcgis.com/zdB7qR0BtYrg0Xpl/arcgis/rest/services/CCD_Zoning/FeatureServer/27",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:100fc128becbf39c764b3ace4e902a9b",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -80.1777685208928,
+      25.8393537785387,
+      -80.1756280513227,
+      25.8406285913717
+    ],
+    "centroid": [
+      -80.17668551967735,
+      25.840163783703165
+    ],
+    "apn": "",
+    "zoning_code": "CS",
+    "jurisdiction": "Miami 21 Zoning",
+    "dataset": "Miami 21 Zoning",
+    "source_url": "https://services1.arcgis.com/CvuPhqcTQpZPT9qY/arcgis/rest/services/M21_Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:3c07147b40dcf06591b4654cb8f37887",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -81.3814032760608,
+      28.5188323224889,
+      -81.3796582475575,
+      28.5201939067988
+    ],
+    "centroid": [
+      -81.38029478726521,
+      28.519411292876963
+    ],
+    "apn": "",
+    "zoning_code": "P/T/SP",
+    "jurisdiction": "Orlando Land Use Zoning",
+    "dataset": "Orlando Land Use Zoning",
+    "source_url": "https://services5.arcgis.com/mMuoPCaIYD4wEgDl/arcgis/rest/services/OrlandoLUZoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:e2b92c3596bdf8d79a1cce62caebb3a5",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -72.9291854807887,
+      42.7652471851512,
+      -72.8633662586008,
+      42.8298145156015
+    ],
+    "centroid": [
+      -72.89981066583162,
+      42.79030540202182
+    ],
+    "apn": "",
+    "zoning_code": "Conservation",
+    "jurisdiction": "VT Data - Whitingham Zoning",
+    "dataset": "VT Data - Whitingham Zoning",
+    "source_url": "https://services2.arcgis.com/3xVssd0FD416APnB/arcgis/rest/services/VT_Data_Zoning_20141119_Whitingham/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:97a8bb50cabfa4286b850b7f20aae1e4",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -90.224363606474,
+      39.7325372025223,
+      -90.2225835992194,
+      39.7332820343494
+    ],
+    "centroid": [
+      -90.22340953993341,
+      39.7329113922587
+    ],
+    "apn": "",
+    "zoning_code": "B-4",
+    "jurisdiction": "Zoning",
+    "dataset": "Zoning",
+    "source_url": "https://services3.arcgis.com/95PFahBF8eyGEfuc/arcgis/rest/services/Zoning/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:bc1d5d945d06e6af61ff14eb130212db",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -85.62316129621549,
+      38.36207623349315,
+      -85.61677145058336,
+      38.36607221177001
+    ],
+    "centroid": [
+      -85.62023659241557,
+      38.36391746047157
+    ],
+    "apn": "",
+    "zoning_code": "R1",
+    "jurisdiction": "Jefferson County KY Zoning",
+    "dataset": "Jefferson County KY Zoning",
+    "source_url": "https://gis.lojic.org/maps/rest/services/LojicSolutions/OpenDataDevelopment/MapServer/15",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:e80c515a100c8e7f81101706c1a8310c",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -71.0708197263695,
+      42.3613878082517,
+      -71.0671303715488,
+      42.3658373392046
+    ],
+    "centroid": [
+      -71.06908688976101,
+      42.363554274297755
+    ],
+    "apn": "",
+    "zoning_code": "Business",
+    "jurisdiction": "Boston Zoning Districts 1924",
+    "dataset": "Boston Zoning Districts 1924",
+    "source_url": "https://services.arcgis.com/kbDdtKcFi2adamXa/arcgis/rest/services/Boston_Zoning_Districts_1924/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:b6431de5b4e1028b6d1f22fd2b3f481b",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -71.0809873563304,
+      42.36892672770226,
+      -71.05295019431384,
+      42.38797519150351
+    ],
+    "centroid": [
+      -71.06470364046166,
+      42.376416523177305
+    ],
+    "apn": "2E",
+    "zoning_code": "Charlestown Neighborhood",
+    "jurisdiction": "Boston Zoning Districts",
+    "dataset": "Boston Zoning Districts",
+    "source_url": "https://gis.bostonplans.org/hosting/rest/services/Zoning_Districts/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:7a552082be5360fe7100cbe3962fff69",
+    "crs": "EPSG:4326",
+    "geometry_type": "MultiPolygon",
+    "bbox": [
+      -93.7247685050237,
+      38.741787657821824,
+      -93.71021446285707,
+      38.76817578260518
+    ],
+    "centroid": [
+      -93.72231449031969,
+      38.764245190894066
+    ],
+    "apn": "",
+    "zoning_code": "BO",
+    "jurisdiction": "Zoning Districts Current",
+    "dataset": "Zoning Districts Current",
+    "source_url": "https://gis.warrensburg-mo.com/arcgis/rest/services/Planning/Zoning_Districts_Current/MapServer/7",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:2a2e5c3761d1133f7899d1c9fbb1b6f5",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -115.14387233880126,
+      36.240499167160344,
+      -115.14263297475837,
+      36.24324442587928
+    ],
+    "centroid": [
+      -115.14369332311628,
+      36.24205595228052
+    ],
+    "apn": "",
+    "zoning_code": "PUD",
+    "jurisdiction": "North Las Vegas Zoning",
+    "dataset": "North Las Vegas Zoning",
+    "source_url": "https://maps.clarkcountynv.gov/arcgis/rest/services/GISMO/Zoning/MapServer/9",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:8722bb8868fa60ad0cf990d76b1c1aba",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -73.3079785726401,
+      44.3072036646568,
+      -73.3073421493176,
+      44.3080340186304
+    ],
+    "centroid": [
+      -73.30761874647366,
+      44.3075996111811
+    ],
+    "apn": "",
+    "zoning_code": "CONSERVATION",
+    "jurisdiction": "VT Data - Charlotte Zoning",
+    "dataset": "VT Data - Charlotte Zoning",
+    "source_url": "https://services1.arcgis.com/KVHZNprt62ZdIujN/arcgis/rest/services/VTZONING_Charlotte_poly_zones/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:5a21e64a1f682581e070750d96092df7",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -78.52602765114494,
+      35.86817492086648,
+      -78.52169071375363,
+      35.872177588099454
+    ],
+    "centroid": [
+      -78.52393705499465,
+      35.87030920632838
+    ],
+    "apn": "",
+    "zoning_code": "R-4",
+    "jurisdiction": "Raleigh Zoning",
+    "dataset": "Raleigh Zoning",
+    "source_url": "https://maps.raleighnc.gov/arcgis/rest/services/Planning/Zoning/MapServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:85bb43ec8900b2b231e233e3ff29ad7a",
+    "crs": "EPSG:4326",
+    "geometry_type": "MultiPolygon",
+    "bbox": [
+      -84.41653068405967,
+      39.17322457723663,
+      -84.40196794006641,
+      39.17949193567281
+    ],
+    "centroid": [
+      -84.40879939730489,
+      39.17512439082521
+    ],
+    "apn": "",
+    "zoning_code": "SF-20",
+    "jurisdiction": "Zoning Designation (Cincinnati Only)",
+    "dataset": "Zoning Designation (Cincinnati Only)",
+    "source_url": "https://cagisonline.hamilton-co.org/arcgis/rest/services/Countywide_Layers/Zoning/MapServer/4",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:c22507d8d4b5037ae661b821b4447070",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -82.99396463378785,
+      40.01682035818044,
+      -82.99337777476133,
+      40.018644091438645
+    ],
+    "centroid": [
+      -82.9938172839729,
+      40.01769259679763
+    ],
+    "apn": "",
+    "zoning_code": "Residential",
+    "jurisdiction": "Columbus Base Zoning Districts",
+    "dataset": "Columbus Base Zoning Districts",
+    "source_url": "https://maps2.columbus.gov/arcgis/rest/services/Schemas/BuildingZoning/MapServer/4",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:bbd9852038250f035c128bcffc79c8b0",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -81.6288437132975,
+      41.4784383502341,
+      -81.627723475345,
+      41.4811838651349
+    ],
+    "centroid": [
+      -81.6285870341144,
+      41.479283507425365
+    ],
+    "apn": "",
+    "zoning_code": "GI-B1",
+    "jurisdiction": "Cleveland OH Zoning",
+    "dataset": "Cleveland OH Zoning",
+    "source_url": "https://services7.arcgis.com/ZodPOMBKsdAsTqF4/arcgis/rest/services/Cleveland_OH_Zoning/FeatureServer/32",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:1c1a9c8ee11d204d8d07d3e8fded76a6",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -151.126522915356,
+      60.4741869203623,
+      -151.118929124638,
+      60.4748844909437
+    ],
+    "centroid": [
+      -151.12238749639,
+      60.474500459511205
+    ],
+    "apn": "",
+    "zoning_code": "RR",
+    "jurisdiction": "City of Soldotna Zoning Districts",
+    "dataset": "City of Soldotna Zoning Districts",
+    "source_url": "https://services1.arcgis.com/OYA21y8obYlVqfbj/arcgis/rest/services/zoningdistricts/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:5c4035d280cfd75fda14055803cfba27",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -75.2169956333104,
+      39.9529516867447,
+      -75.2162556550783,
+      39.9533814765754
+    ],
+    "centroid": [
+      -75.21657809644805,
+      39.95315507427571
+    ],
+    "apn": "",
+    "zoning_code": "SP-PO-A",
+    "jurisdiction": "Philadelphia PA Zoning",
+    "dataset": "Philadelphia PA Zoning",
+    "source_url": "https://services7.arcgis.com/ZodPOMBKsdAsTqF4/arcgis/rest/services/Philadelphia_PA_Zoning/FeatureServer/18",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:fb1386f7c8d70db6a27adc52e0cea062",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -75.1544167452959,
+      39.9653668194054,
+      -75.1536309499564,
+      39.9663771770489
+    ],
+    "centroid": [
+      -75.15406764358988,
+      39.965762080121436
+    ],
+    "apn": "",
+    "zoning_code": "Residential/Residential Mixed-Use",
+    "jurisdiction": "zoning base philadelphia 2012 08",
+    "dataset": "zoning base philadelphia 2012 08",
+    "source_url": "https://services3.arcgis.com/9nfxWATFamVUTTGb/arcgis/rest/services/zoning_base_philadelphia_2012_08/FeatureServer/0",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:ce33d5c267798947f6f6beefec70c86e",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -98.4652136215359,
+      29.4820856192137,
+      -98.4637636265813,
+      29.4824906887448
+    ],
+    "centroid": [
+      -98.46451537546292,
+      29.482304870277975
+    ],
+    "apn": "",
+    "zoning_code": "2F-C",
+    "jurisdiction": "San Antonio Area Zoning",
+    "dataset": "San Antonio Area Zoning",
+    "source_url": "https://services7.arcgis.com/ZodPOMBKsdAsTqF4/arcgis/rest/services/San_Antonio_Area_Zoning/FeatureServer/102",
+    "ordinance_url": ""
+  },
+  {
+    "parcel_id": "geo:5168947d10edf60d37bdf1dc4c1c7383",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -111.648320459423,
+      40.5853559830913,
+      -111.646077879708,
+      40.5870759687974
+    ],
+    "centroid": [
+      -111.64739365992983,
+      40.58647514108409
+    ],
+    "apn": "",
+    "zoning_code": "Blackjack Village Subdivision",
+    "jurisdiction": "Salt Lake County Municipal Zoning Map",
+    "dataset": "Salt Lake County Municipal Zoning Map",
+    "source_url": "https://services1.arcgis.com/DJP723NX3ukQ2LtF/ArcGIS/rest/services/Salt_Lake_County_Zoning_2023_WFL1/FeatureServer/2",
+    "ordinance_url": "https://townofalta.com/docs/22.7.Forest&Rec.pdf"
+  },
+  {
+    "parcel_id": "geo:3058fe6341361ff94950219639193ebb",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -89.40836932467988,
+      43.041230230375014,
+      -89.40397042678669,
+      43.04229670436338
+    ],
+    "centroid": [
+      -89.40610086514448,
+      43.04203792792073
+    ],
+    "apn": "",
+    "zoning_code": "IL",
+    "jurisdiction": "Zoning Districts - current",
+    "dataset": "Zoning Districts - current",
+    "source_url": "https://maps.cityofmadison.com/arcgis/rest/services/Public/OPEN_DATA/MapServer/9",
+    "ordinance_url": "https://library.municode.com/wi/madison/codes/code_of_ordinances?nodeId=COORMAWIVOIICH11--19_CH28ZOCOOR"
+  },
+  {
+    "parcel_id": "geo:ca455b38e319c75b20f7523217f2f66f",
+    "crs": "EPSG:4326",
+    "geometry_type": "Polygon",
+    "bbox": [
+      -79.04268114817914,
+      35.93377764488627,
+      -79.03142082562083,
+      35.940291093470385
+    ],
+    "centroid": [
+      -79.03486371150233,
+      35.93541235747515
+    ],
+    "apn": "",
+    "zoning_code": "Neighborhood Conservation",
+    "jurisdiction": "Overlay Zoning Districts",
+    "dataset": "Overlay Zoning Districts",
+    "source_url": "https://gis-portal.townofchapelhill.org/server/rest/services/OpenData/Overlay_Zoning_Districts/MapServer/0",
+    "ordinance_url": ""
+  }
+]

--- a/examples/zoning_intelligence.py
+++ b/examples/zoning_intelligence.py
@@ -1,0 +1,149 @@
+"""Zoning Intelligence × Context Runtime — the geospatial reference benchmark (plan §6, §14), offline.
+
+Given a parcel and a target use, the Runtime must conclude the land-use disposition (PERMITTED /
+CONDITIONAL / PROHIBITED / UNKNOWN) from heterogeneous evidence — commercial providers (Regrid, ATTOM),
+the official municipal GIS, and the zoning ordinance. The decision the Runtime learns is *which evidence
+to acquire*: the cheapest bundle that still reaches the correct, safe answer.
+
+The benchmark shows the three arms from the plan:
+
+  A · single-provider (Regrid only)   — cheap, but MISSES overlay/conditional cases AND produces a
+                                        "verified permitted" that is actually prohibited (SLO violation).
+  B · fixed thorough (all sources)     — correct everywhere, but always pays for the ordinance.
+  C · Context Runtime (learned)        — matches B's correctness at lower cost by learning, per
+                                        use-difficulty bucket, the minimal sufficient evidence bundle.
+
+Everything is offline and deterministic (a fixture Fulton County jurisdiction). Then: a use-first land
+search, an incremental evidence change (dependency-scoped recomputation), and a population-governance
+shift (a provider drifting CONDITIONAL→PERMITTED across the population).
+
+    PYTHONPATH=. python examples/zoning_intelligence.py
+"""
+from __future__ import annotations
+
+from context_runtime.geospatial.contracts import UseDisposition as D
+from context_runtime.integrations.zoning_intelligence import (
+    DEFAULT_ARMS, EvidencePlan, PopulationGovernor, ZoningIntelligenceTenant, affected_conclusions,
+    build_providers, build_reference_world, gold_disposition, resolve_disposition, reward_zoning,
+    zoning_bucket, _zoning_bandit,
+)
+
+# Curated decision-relevant queries per use-difficulty bucket — the parcels/uses where the evidence tier
+# actually matters (a zoning analyst does not ask whether a warehouse fits a clearly-residential lot).
+QUERIES: list[tuple[str, str]] = [
+    # residential: base zoning decides; commercial consensus resolves the stale-Regrid trap (R-102)
+    ("R-100", "RESIDENTIAL_SINGLE_FAMILY"), ("R-101", "RESIDENTIAL_SINGLE_FAMILY"),
+    ("R-102", "RESIDENTIAL_SINGLE_FAMILY"),
+    # commercial: overlay-sensitive → needs the official GIS (O-201 sits under a FLOOD overlay)
+    ("O-200", "OFFICE"), ("O-200", "RETAIL"), ("O-201", "OFFICE"), ("R-102", "OFFICE"),
+    # industrial: conditional → needs the ordinance text (W-301 sits under a HISTORIC overlay)
+    ("W-300", "WAREHOUSE"), ("W-300", "LIGHT_INDUSTRIAL"), ("D-401", "DATA_CENTER"),
+    ("D-401", "LIGHT_INDUSTRIAL"), ("W-301", "WAREHOUSE"),
+]
+
+
+_ARM_BY_KEY = {a.key: a for a in DEFAULT_ARMS}
+
+
+def _eval(world, providers, apn, pick) -> tuple[float, float, int]:
+    """Average reward, average cost, and false-permitted count of a policy over the stream. ``pick`` maps
+    a (bucket, use) to the EvidencePlan to run — a constant (fixed baseline) or the learned policy."""
+    total = cost = 0.0
+    false_permits = 0
+    for a_apn, use in QUERIES:
+        pid = apn[a_apn]
+        arm = pick(zoning_bucket(use))
+        gold = gold_disposition(world, providers, pid, use)
+        a = resolve_disposition(world, providers, pid, use, arm.sources)
+        correct = a.disposition == gold
+        fp = a.disposition == D.PERMITTED and gold == D.PROHIBITED
+        total += reward_zoning(correct=correct, false_permitted=fp, cost_units=arm.cost_units(providers))
+        cost += arm.cost_units(providers)
+        false_permits += 1 if fp else 0
+    n = len(QUERIES)
+    return total / n, cost / n, false_permits
+
+
+def run(rounds: int = 260) -> None:
+    world, apn = build_reference_world()
+    providers = build_providers(world)
+    tenant = ZoningIntelligenceTenant(world=world, bandit=_zoning_bandit(epsilon=0.1))
+
+    print("Parcel-first assessments (evidence bundle chosen by the Runtime, learning the minimal set):\n")
+    online_false_permits = 0
+    for i in range(rounds):
+        a_apn, use = QUERIES[i % len(QUERIES)]
+        pid = apn[a_apn]
+        qid = f"q{i}"
+        assessment = tenant.assess(qid, pid, use)
+        gold = gold_disposition(world, providers, pid, use)
+        tenant.record(qid, gold)
+        if assessment.disposition == D.PERMITTED and gold == D.PROHIBITED:
+            online_false_permits += 1
+        if i < len(QUERIES):
+            ok = "✓" if assessment.disposition == gold else ("·" if assessment.disposition == D.UNKNOWN else "✗")
+            print(f"  [{zoning_bucket(use):<11}] {a_apn} {use:<26} → {assessment.disposition.value:<11} "
+                  f"{ok}  sources={'+'.join(assessment.sources_used)}")
+
+    # C is the DEPLOYED (converged, greedy) policy — exploitation, no exploration noise. A/B are fixed.
+    learned = tenant.policy()
+    lr, lc, lfp = _eval(world, providers, apn, lambda b: _ARM_BY_KEY[learned[b]])
+    ar, ac, afp = _eval(world, providers, apn, lambda b: DEFAULT_ARMS[0])      # A: single provider
+    br, bc, bfp = _eval(world, providers, apn, lambda b: DEFAULT_ARMS[-1])     # B: fixed thorough
+
+    print("\nreward = correct disposition − λ·evidence-cost;  false-permit = −1 (the blocking SLO)\n")
+    print(f"  C · Context Runtime (learned bundle/bucket): reward {lr:+.3f}   avg cost {lc:.2f}u   "
+          f"false-permits {lfp}")
+    a_flag = "   ← violates SLO" if afp else ""
+    print(f"  A · single provider (Regrid only):           reward {ar:+.3f}   avg cost {ac:.2f}u   "
+          f"false-permits {afp}{a_flag}")
+    print(f"  B · fixed thorough (all sources):            reward {br:+.3f}   avg cost {bc:.2f}u   "
+          f"false-permits {bfp}")
+    print(f"\n  learned vs single-provider:  reward {lr - ar:+.3f}   (0 SLO violations vs {afp})")
+    print(f"  learned vs fixed-thorough:   reward {lr - br:+.3f}   cost {lc - bc:+.2f}u "
+          f"({bc / lc:.1f}× cheaper at equal correctness)")
+    print(f"  (during learning, {rounds} rounds at ε=0.1: {online_false_permits} exploratory SLO trips — "
+          f"converged policy trips 0)")
+
+    print("\n── learned minimal evidence bundle per use-difficulty bucket ──")
+    for bucket in ("residential", "commercial", "industrial"):
+        pol = tenant.policy().get(bucket, "—")
+        print(f"  {bucket:<12} → {pol}")
+
+    # EXPLAIN for one industrial parcel — every conclusion shows exactly which evidence produced it.
+    tenant.assess("explain-demo", apn["D-401"], "DATA_CENTER")
+    exp = tenant.explain("explain-demo")
+    print(f"\n── EXPLAIN · D-401 / DATA_CENTER ──\n  selected={exp['selected']}  "
+          f"disposition={exp['disposition']}  confidence={exp['confidence']}")
+    for r in exp["reasons"]:
+        print(f"    · {r}")
+
+    # ── use-first land search (plan §6, §12): deterministic spatial filter + learned evidence ──
+    hits = tenant.search("LIGHT_INDUSTRIAL", center=(1050, 1300), radius=1200, min_lot_area=40000)
+    print("\n── LAND SEARCH · LIGHT_INDUSTRIAL within 1200ft of (1050,1300), lot ≥ 40,000 ft² ──")
+    for h in hits:
+        print(f"  {world.parcels[h.parcel_id].apn}  {h.disposition.value}  "
+              f"lot={world.parcels[h.parcel_id].lot_area:.0f}ft²  ({'+'.join(h.sources_used)})")
+
+    # ── incremental evidence change (plan §17): a new overlay → recompute only dependent parcels ──
+    new_overlay = [(850, 1050), (1400, 1050), (1400, 1600), (850, 1600)]   # now covers D-401
+    affected = affected_conclusions(world, changed_parcel_ids=set(), changed_overlay_rings=[new_overlay])
+    print(f"\n── INCREMENTAL · new overlay district → recompute {len(affected)} of "
+          f"{len(world.parcels)} parcels ──")
+    print("  affected: " + ", ".join(sorted(world.parcels[p].apn for p in affected)))
+
+    # ── population governance (plan §18): a provider drifts CONDITIONAL→PERMITTED across the population ──
+    gov = PopulationGovernor(baseline_rate=0.0, threshold=0.25, window=20)
+    for i in range(20):
+        gov.observe("ordinance", downgraded=False)       # healthy baseline
+    healthy = gov.review_required("ordinance")
+    for i in range(20):
+        gov.observe("ordinance", downgraded=(i % 2 == 0))  # ~50% now silently downgraded
+    drifted = gov.review_required("ordinance")
+    print("\n── POPULATION GOVERNANCE · ordinance classifier drift ──")
+    print(f"  healthy window review_required={healthy}  →  drifted window review_required={drifted} "
+          f"(recent downgrade rate {gov.recent_rate('ordinance'):.0%})")
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/zoning_real_world.py
+++ b/examples/zoning_real_world.py
@@ -18,10 +18,16 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 from context_runtime.geospatial.contracts import GeoRef, ParcelEntity, UseDisposition as D
 
-DATA = os.path.join(os.path.dirname(__file__), "data", "harvested_brisbane_ca.json")
+_HERE = os.path.join(os.path.dirname(__file__), "data")
+# Default = the Brisbane fixture; pass a path (or `nationwide` for the 32-parcel cross-country sample
+# drawn from the 149,624-district nationwide harvest) to run on more real data.
+_ALIASES = {"brisbane": "harvested_brisbane_ca.json", "nationwide": "harvested_us_sample.json"}
+_arg = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("ZONING_DATA", "brisbane")
+DATA = _arg if os.path.isabs(_arg) else os.path.join(_HERE, _ALIASES.get(_arg, _arg))
 
 TARGET_USES = ("RESIDENTIAL_SINGLE_FAMILY", "OFFICE", "RETAIL", "WAREHOUSE", "LIGHT_INDUSTRIAL")
 
@@ -75,25 +81,38 @@ def fam_of(use: str) -> str:
 
 def run() -> None:
     universe = json.load(open(DATA, encoding="utf-8"))
+    datasets = {rec.get("dataset") or rec.get("jurisdiction") or "" for rec in universe}
+    detailed = len(universe) <= 6                     # full per-use detail for a small set; else aggregate
     print(f"Real parcels harvested from official sources: {len(universe)} "
-          f"(jurisdiction: {universe[0]['jurisdiction']})\n")
+          f"across {len(datasets)} dataset(s)/jurisdiction(s)\n")
 
     false_permits = 0
+    tally = {"PERMITTED": 0, "PROHIBITED": 0, "UNKNOWN": 0}
     for rec in universe:
         parcel = as_parcel(rec)                       # proves the drop-in GeoRef/ParcelEntity contract
-        print(f"■ {parcel.zoning_codes[0]:6} parcel {parcel.parcel_id[:22]}  "
-              f"({parcel.geometry_ref.geometry_type}, {parcel.jurisdiction})")
-        if rec.get("ordinance_url"):
-            print(f"    ordinance: {rec['ordinance_url']}")
+        marks = ""
         for use in TARGET_USES:
             disp, why = resolve_real(rec, use)
+            tally[disp.value] = tally.get(disp.value, 0) + 1
             mark = {"PERMITTED": "✓", "PROHIBITED": "✗", "UNKNOWN": "·"}.get(disp.value, "?")
-            print(f"      {mark} {use:26} → {disp.value:11} — {why}")
+            marks += mark
+            if detailed:
+                print(f"      {mark} {use:26} → {disp.value:11} — {why}")
             # A conclusion can never be a confident PERMITTED without base compatibility; assert the SLO.
             if disp == D.PERMITTED and code_family(rec["zoning_code"]) != USE_FAMILY[use]:
                 false_permits += 1
-        print()
+        if detailed:
+            print(f"■ {parcel.zoning_codes[0]:6} parcel {parcel.parcel_id[:22]}  "
+                  f"({parcel.geometry_ref.geometry_type}, {parcel.jurisdiction})")
+            if rec.get("ordinance_url"):
+                print(f"    ordinance: {rec['ordinance_url']}")
+            print()
+        else:
+            juris = (rec.get("dataset") or parcel.jurisdiction or "")[:34]
+            print(f"  {marks}  {(parcel.zoning_codes[0] or '')[:14]:14} {juris}")
 
+    print(f"\ndispositions across {len(universe)} parcels × {len(TARGET_USES)} uses: "
+          f"{tally['PERMITTED']} permitted · {tally['PROHIBITED']} prohibited · {tally['UNKNOWN']} unknown")
     print(f"false-permits (concluded PERMITTED against incompatible base): {false_permits}  "
           f"— the SLO holds on real data")
     print("Wherever the answer depends on the ordinance's use table (the deep wall), the runtime returns "

--- a/examples/zoning_real_world.py
+++ b/examples/zoning_real_world.py
@@ -1,0 +1,104 @@
+"""Zoning intelligence on REAL, directly-harvested official data (not the synthetic fixture).
+
+The parcels in `examples/data/harvested_brisbane_ca.json` were harvested live from OFFICIAL keyless
+sources by the `zoning-sources-mcp` server (US Census geocoder → ArcGIS Hub discovery → ArcGIS REST
+query against Brisbane, CA's own published zoning layer). Each carries a canonical `geometry_hash` id, the
+real zoning code, and a link to the district's ordinance page.
+
+This demo shows the runtime concluding on that real data with the SAME deterministic-first, fail-safe
+discipline as the tenant: the official base zoning is authoritative, so base-incompatible uses are
+PROHIBITED with certainty; but where a use's permissibility depends on the ordinance's permitted-use
+table or an overlay we have NOT parsed (the honest "deep wall"), the runtime abstains to UNKNOWN and cites
+the ordinance URL for verification — never a false "permitted". That abstention IS the false-permitted=0
+SLO, now demonstrated on real official data.
+
+    PYTHONPATH=. python examples/zoning_real_world.py
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from context_runtime.geospatial.contracts import GeoRef, ParcelEntity, UseDisposition as D
+
+DATA = os.path.join(os.path.dirname(__file__), "data", "harvested_brisbane_ca.json")
+
+TARGET_USES = ("RESIDENTIAL_SINGLE_FAMILY", "OFFICE", "RETAIL", "WAREHOUSE", "LIGHT_INDUSTRIAL")
+
+# Family of a use, and the family a real zoning code implies (from its prefix — the real-world taxonomy is
+# per-jurisdiction, so this is a coarse, honest classifier, not a claim of full ordinance parsing).
+USE_FAMILY = {
+    "RESIDENTIAL_SINGLE_FAMILY": "residential",
+    "OFFICE": "commercial", "RETAIL": "commercial",
+    "WAREHOUSE": "industrial", "LIGHT_INDUSTRIAL": "industrial",
+}
+# Uses that need the ordinance's permitted-use table / an overlay check before PERMITTED can be confirmed.
+NEEDS_ORDINANCE = {"OFFICE", "RETAIL", "WAREHOUSE", "LIGHT_INDUSTRIAL"}
+
+
+def code_family(code: str) -> str:
+    c = (code or "").strip().upper()
+    if c.startswith(("R-", "R", "RH", "RM", "RS")) and not c.startswith("RET"):
+        return "residential"
+    if c.startswith(("C-", "C", "CB", "CG", "CN", "TC", "MU")):
+        return "commercial"
+    if c.startswith(("M-", "M", "I-", "I", "IL", "IG", "IND", "PI")):
+        return "industrial"
+    return "unknown"
+
+
+def as_parcel(rec: dict) -> ParcelEntity:
+    """Rebuild the runtime's ParcelEntity/GeoRef from a harvested record (same geometry_hash identity)."""
+    ref = GeoRef(geometry_type=rec["geometry_type"], geometry_hash=rec["parcel_id"], crs=rec["crs"],
+                 bbox=tuple(rec["bbox"]), centroid=tuple(rec["centroid"]),
+                 jurisdiction=rec["jurisdiction"], source=rec.get("source_url", ""))
+    return ParcelEntity(parcel_id=rec["parcel_id"], geometry_ref=ref, apn=rec.get("apn", ""),
+                        jurisdiction=rec["jurisdiction"], zoning_codes=[rec["zoning_code"]])
+
+
+def resolve_real(rec: dict, use: str) -> tuple[D, str]:
+    """Deterministic-first + fail-safe on the official base zoning alone. PERMITTED only for the archetypal
+    base-by-right case; UNKNOWN (never a guess) where the ordinance/overlay is needed but unparsed."""
+    fam = code_family(rec["zoning_code"])
+    if fam == "unknown":
+        return D.UNKNOWN, "zoning-code family unrecognized — cannot conclude from base alone"
+    if USE_FAMILY[use] != fam:
+        return D.PROHIBITED, f"official base zoning {rec['zoning_code']} ({fam}) excludes a {fam_of(use)} use"
+    if use in NEEDS_ORDINANCE:
+        return D.UNKNOWN, "base-compatible, but permitted/conditional status needs the ordinance — verify"
+    return D.PERMITTED, f"official base zoning {rec['zoning_code']} permits {use.lower().replace('_',' ')} by right"
+
+
+def fam_of(use: str) -> str:
+    return USE_FAMILY[use]
+
+
+def run() -> None:
+    universe = json.load(open(DATA, encoding="utf-8"))
+    print(f"Real parcels harvested from official sources: {len(universe)} "
+          f"(jurisdiction: {universe[0]['jurisdiction']})\n")
+
+    false_permits = 0
+    for rec in universe:
+        parcel = as_parcel(rec)                       # proves the drop-in GeoRef/ParcelEntity contract
+        print(f"■ {parcel.zoning_codes[0]:6} parcel {parcel.parcel_id[:22]}  "
+              f"({parcel.geometry_ref.geometry_type}, {parcel.jurisdiction})")
+        if rec.get("ordinance_url"):
+            print(f"    ordinance: {rec['ordinance_url']}")
+        for use in TARGET_USES:
+            disp, why = resolve_real(rec, use)
+            mark = {"PERMITTED": "✓", "PROHIBITED": "✗", "UNKNOWN": "·"}.get(disp.value, "?")
+            print(f"      {mark} {use:26} → {disp.value:11} — {why}")
+            # A conclusion can never be a confident PERMITTED without base compatibility; assert the SLO.
+            if disp == D.PERMITTED and code_family(rec["zoning_code"]) != USE_FAMILY[use]:
+                false_permits += 1
+        print()
+
+    print(f"false-permits (concluded PERMITTED against incompatible base): {false_permits}  "
+          f"— the SLO holds on real data")
+    print("Wherever the answer depends on the ordinance's use table (the deep wall), the runtime returns "
+          "UNKNOWN and cites the official source — it never fabricates a 'permitted'.")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_geospatial.py
+++ b/tests/test_geospatial.py
@@ -1,0 +1,71 @@
+"""Geospatial engine + contracts — deterministic CPU spatial operations."""
+from __future__ import annotations
+
+import pytest
+
+from context_runtime.geospatial import contracts as C
+from context_runtime.geospatial import engine as E
+
+# a unit square [0,10]x[0,10] and a smaller one overlapping it
+SQ = [(0, 0), (10, 0), (10, 10), (0, 10)]
+SQ2 = [(5, 5), (15, 5), (15, 15), (5, 15)]
+FAR = [(100, 100), (110, 100), (110, 110), (100, 110)]
+
+
+def test_point_in_polygon():
+    assert E.point_in_polygon((5, 5), SQ) is True
+    assert E.point_in_polygon((0, 0), SQ) is True        # boundary counts as inside (deterministic)
+    assert E.point_in_polygon((11, 5), SQ) is False
+
+
+def test_point_in_polygon_with_hole():
+    hole = [(3, 3), (7, 3), (7, 7), (3, 7)]
+    assert E.point_in_polygon((1, 1), SQ, [hole]) is True
+    assert E.point_in_polygon((5, 5), SQ, [hole]) is False    # inside the hole → outside the polygon
+
+
+def test_area_and_centroid():
+    assert E.area(SQ) == pytest.approx(100.0)                 # 10x10 planar square
+    assert E.centroid(SQ) == pytest.approx((5.0, 5.0))
+
+
+def test_distance():
+    assert E.distance((0, 0), (3, 4)) == pytest.approx(5.0)
+
+
+def test_polygons_intersect():
+    assert E.polygons_intersect(SQ, SQ2) is True             # overlapping corners
+    assert E.polygons_intersect(SQ, FAR) is False            # bbox-disjoint
+    # containment (one inside the other) is an intersection
+    inner = [(2, 2), (4, 2), (4, 4), (2, 4)]
+    assert E.polygons_intersect(SQ, inner) is True
+
+
+def test_spatial_join_by_centroid():
+    parcels = [("p1", [(1, 1), (2, 1), (2, 2), (1, 2)], "EPSG:2240"),   # centroid (1.5,1.5) ∈ SQ
+               ("p2", [(20, 20), (21, 20), (21, 21), (20, 21)], "EPSG:2240")]  # far away
+    zones = [("R1", SQ, "EPSG:2240")]
+    out = E.spatial_join_by_centroid(parcels, zones)
+    assert out["p1"] == ["R1"] and out["p2"] == []
+
+
+def test_crs_mismatch_is_never_silent():
+    parcels = [("p1", [(1, 1), (2, 1), (2, 2)], "EPSG:4326")]
+    zones = [("R1", SQ, "EPSG:2240")]
+    with pytest.raises(E.CrsMismatch):
+        E.spatial_join_by_centroid(parcels, zones)
+
+
+def test_geometry_hash_is_canonical_and_stable():
+    h1 = C.geometry_hash([SQ], "EPSG:2240")
+    h2 = C.geometry_hash([[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]], "EPSG:2240")
+    assert h1 == h2 and h1.startswith("geo:")                # same boundary+CRS → one identity
+    assert C.geometry_hash([SQ], "EPSG:4326") != h1          # CRS is part of identity
+
+
+def test_georef_and_parcel_construct():
+    ref = C.GeoRef(geometry_type="Polygon", geometry_hash=C.geometry_hash([SQ], "EPSG:2240"),
+                   crs="EPSG:2240", bbox=E.bbox(SQ), centroid=E.centroid(SQ), jurisdiction="Fulton County")
+    parcel = C.ParcelEntity(parcel_id=ref.geometry_hash, geometry_ref=ref, lot_area=E.area(SQ))
+    assert parcel.lot_area == pytest.approx(100.0)
+    assert parcel.geometry_ref.crs == "EPSG:2240"

--- a/tests/test_integration_zoning_intelligence.py
+++ b/tests/test_integration_zoning_intelligence.py
@@ -1,0 +1,162 @@
+"""Zoning Intelligence tenant — the geospatial reference benchmark (offline, deterministic).
+
+Asserts the plan's load-bearing properties: deterministic-first constraints, reconciliation that makes
+false-permitted structurally impossible (the blocking SLO), the learned minimal-evidence policy per
+use-difficulty bucket, that it beats both baselines, dependency-scoped incremental recomputation, and
+population-governance drift detection.
+"""
+from __future__ import annotations
+
+from context_runtime.geospatial.contracts import UseDisposition as D
+from context_runtime.integrations.zoning_intelligence import (
+    DEFAULT_ARMS, EvidencePlan, PopulationGovernor, ZoningIntelligenceTenant, affected_conclusions,
+    build_providers, build_reference_world, gold_disposition, resolve_disposition, reward_zoning,
+    zoning_bucket, _zoning_bandit,
+)
+from examples.zoning_intelligence import QUERIES, _ARM_BY_KEY, _eval
+
+
+def _world():
+    world, apn = build_reference_world()
+    return world, apn, build_providers(world)
+
+
+# ── vocabulary / arms / reward ──
+
+def test_bucketing():
+    assert zoning_bucket("RESIDENTIAL_SINGLE_FAMILY") == "residential"
+    assert zoning_bucket("OFFICE") == "commercial" and zoning_bucket("RETAIL") == "commercial"
+    assert zoning_bucket("WAREHOUSE") == zoning_bucket("DATA_CENTER") == "industrial"
+
+
+def test_arm_key_and_cost_ordering():
+    _, _, prov = _world()
+    assert DEFAULT_ARMS[0].key == "regrid"
+    assert DEFAULT_ARMS[-1].key == "regrid+attom+municipal_gis+ordinance"
+    costs = [a.cost_units(prov) for a in DEFAULT_ARMS]
+    assert costs == sorted(costs) and costs[0] < costs[-1]     # escalating bundles cost strictly more
+
+
+def test_reward_penalizes_false_permit_and_rewards_cheaper():
+    cheap, dear = DEFAULT_ARMS[1], DEFAULT_ARMS[-1]
+    _, _, prov = _world()
+    assert reward_zoning(correct=False, false_permitted=True, cost_units=1.0) == -1.0    # the SLO penalty
+    assert reward_zoning(correct=False, false_permitted=False, cost_units=1.0) == 0.0    # a plain miss
+    r_cheap = reward_zoning(correct=True, false_permitted=False, cost_units=cheap.cost_units(prov))
+    r_dear = reward_zoning(correct=True, false_permitted=False, cost_units=dear.cost_units(prov))
+    assert r_cheap > r_dear > 0.0                                                        # cheaper-correct wins
+
+
+# ── deterministic-first + fail-safe resolver ──
+
+def test_deterministic_constraint_precedes_interpretation():
+    """A data center on an undersized lot (D-400) is PROHIBITED by the structured lot-area constraint even
+    with the full evidence set — geometry before any ordinance/LLM interpretation (plan §4)."""
+    world, apn, prov = _world()
+    a = resolve_disposition(world, prov, apn["D-400"], "DATA_CENTER",
+                            ("regrid", "attom", "municipal_gis", "ordinance"))
+    assert a.disposition == D.PROHIBITED
+    assert a.constraints and a.constraints[0].type.value == "MIN_LOT_AREA"
+
+
+def test_single_provider_can_false_permit_but_reconciliation_cannot():
+    """R-102's true base is C-2 but Regrid is stale (R-1). Regrid-only concludes a residence is PERMITTED
+    where it is actually PROHIBITED — a false-permit. Adding the independent ATTOM source (reconciliation)
+    turns it into a safe UNKNOWN. This is the blocking SLO in action (plan §16)."""
+    world, apn, prov = _world()
+    gold = gold_disposition(world, prov, apn["R-102"], "RESIDENTIAL_SINGLE_FAMILY")
+    assert gold == D.PROHIBITED
+    solo = resolve_disposition(world, prov, apn["R-102"], "RESIDENTIAL_SINGLE_FAMILY", ("regrid",))
+    assert solo.disposition == D.PERMITTED       # single stale provider → false permit
+    recon = resolve_disposition(world, prov, apn["R-102"], "RESIDENTIAL_SINGLE_FAMILY", ("regrid", "attom"))
+    assert recon.disposition == D.UNKNOWN        # reconciliation refuses to guess
+
+
+def test_thorough_bundle_has_zero_false_permits_everywhere():
+    """The blocking SLO: across every parcel × target use, the full evidence set never concludes PERMITTED
+    where the truth is PROHIBITED."""
+    from context_runtime.integrations.zoning_intelligence import TARGET_USES
+    world, apn, prov = _world()
+    full = ("regrid", "attom", "municipal_gis", "ordinance")
+    for pid in world.parcels:
+        for use in TARGET_USES:
+            gold = gold_disposition(world, prov, pid, use)
+            d = resolve_disposition(world, prov, pid, use, full).disposition
+            assert not (d == D.PERMITTED and gold == D.PROHIBITED)
+
+
+def test_abstains_when_decisive_source_absent():
+    """An overlay-sensitive commercial use with no official GIS cannot confirm 'no restrictive overlay',
+    so it abstains to UNKNOWN rather than guessing PERMITTED (plan §9: don't force a binary)."""
+    world, apn, prov = _world()
+    a = resolve_disposition(world, prov, apn["O-200"], "OFFICE", ("regrid", "attom"))
+    assert a.disposition == D.UNKNOWN
+
+
+# ── tenant: choose / record / explain ──
+
+def test_assess_records_pending_and_explains():
+    world, apn, _ = _world()
+    tenant = ZoningIntelligenceTenant(world=world)
+    a = tenant.assess("q1", apn["O-200"], "OFFICE")
+    assert a.disposition in set(D)
+    exp = tenant.explain("q1")
+    assert exp["bucket"] == "commercial"
+    assert exp["selected"] in {arm.key for arm in DEFAULT_ARMS}
+    assert len(exp["scores"]) == len(DEFAULT_ARMS)
+
+
+# ── learning: converged policy per bucket + beats baselines ──
+
+def test_learns_minimal_evidence_bundle_per_bucket():
+    world, apn, prov = _world()
+    tenant = ZoningIntelligenceTenant(world=world, bandit=_zoning_bandit(epsilon=0.1))
+    for i in range(300):
+        a_apn, use = QUERIES[i % len(QUERIES)]
+        qid = f"q{i}"
+        tenant.assess(qid, apn[a_apn], use)
+        tenant.record(qid, gold_disposition(world, prov, apn[a_apn], use))
+    pol = tenant.policy()
+    # residential + commercial resolve WITHOUT the expensive ordinance; industrial needs it.
+    assert "ordinance" not in pol["residential"]
+    assert "ordinance" not in pol["commercial"]
+    assert pol["industrial"] == DEFAULT_ARMS[-1].key
+
+
+def test_learned_policy_beats_both_baselines_and_holds_the_slo():
+    world, apn, prov = _world()
+    tenant = ZoningIntelligenceTenant(world=world, bandit=_zoning_bandit(epsilon=0.1))
+    for i in range(300):
+        a_apn, use = QUERIES[i % len(QUERIES)]
+        qid = f"q{i}"
+        tenant.assess(qid, apn[a_apn], use)
+        tenant.record(qid, gold_disposition(world, prov, apn[a_apn], use))
+    learned = tenant.policy()
+    lr, lc, lfp = _eval(world, prov, apn, lambda b: _ARM_BY_KEY[learned[b]])
+    ar, ac, afp = _eval(world, prov, apn, lambda b: DEFAULT_ARMS[0])     # single provider
+    br, bc, bfp = _eval(world, prov, apn, lambda b: DEFAULT_ARMS[-1])    # fixed thorough
+    assert lr > ar                       # beats single-provider on correctness
+    assert lc < bc                       # cheaper than always-thorough
+    assert lr >= br - 1e-9               # at least matches thorough's reward (correctness)
+    assert lfp == 0 and afp >= 1         # the SLO: learned trips 0, single-provider trips ≥1
+
+
+# ── incremental change + population governance ──
+
+def test_incremental_recomputation_is_dependency_scoped():
+    world, apn, _ = _world()
+    # An overlay covering only D-401's footprint must mark exactly D-401 stale — nothing else.
+    ring = [(850, 1050), (1400, 1050), (1400, 1600), (850, 1600)]
+    affected = affected_conclusions(world, changed_parcel_ids=set(), changed_overlay_rings=[ring])
+    assert affected == {apn["D-401"]}
+    assert len(affected) < len(world.parcels)
+
+
+def test_population_governance_detects_systematic_drift():
+    gov = PopulationGovernor(baseline_rate=0.0, threshold=0.25, window=20)
+    for _ in range(20):
+        gov.observe("ordinance", downgraded=False)
+    assert gov.review_required("ordinance") is False           # healthy population, no review
+    for i in range(20):
+        gov.observe("ordinance", downgraded=(i % 2 == 0))       # ~50% silently downgraded
+    assert gov.review_required("ordinance") is True            # cross-population shift → REQUIRE_REVIEW


### PR DESCRIPTION
Adds geospatial as a first-class Context Runtime capability — typed spatial evidence, a deterministic CPU-authoritative spatial engine, and a zoning-intelligence reference tenant that learns the minimal evidence bundle to reach a correct land-use disposition. Additive and offline; no new hard dependencies.

## What's in it
- **Typed spatial evidence** (`context_runtime/geospatial/contracts.py`): `GeoRef` (frozen; content-addressed `geometry_hash` via blake2b; crs/bbox/centroid/jurisdiction/valid_time/source), `SpatialOp`, `UseDisposition` (incl. **UNKNOWN**), `USE_ONTOLOGY`, `LandUseConstraint`, `ParcelEntity` (keeps provider provenance).
- **Deterministic spatial engine** (`geospatial/engine.py`): pure-Python, dependency-free — point-in-polygon (ray casting), polygon intersection (bbox prefilter + edge crossing), shoelace area, centroid, distance, centroid spatial join. Raises `CrsMismatch` on a binary op across CRSs — **no silent reprojection**. Heavier backends (shapely/PostGIS/DuckDB-Spatial/GPU) are planner-selectable later.
- **Zoning-intelligence tenant** (`integrations/zoning_intelligence.py`): deterministic-first fail-safe resolver, bandit-driven adaptive evidence acquisition over Regrid/ATTOM/municipal-GIS/ordinance, a **false-permit = 0 blocking SLO**, incremental recompute, and population-governance drift detection.

## Measured (offline, real numbers from `examples/`)
- `zoning_intelligence.py`: learned per-bucket bundle **reward +0.894 at avg cost 5.67u, 0 false-permits** vs single-provider (+0.080, **1 SLO violation**) and fixed-thorough (+0.850 at 8.00u) — **1.4× cheaper at equal correctness, zero SLO violations**.
- `zoning_real_world.py`: runs on real harvested official data (Brisbane CA ArcGIS R-1) — **false-permits: 0**; wherever the answer needs the ordinance use-table it returns **UNKNOWN and cites the source**, never fabricating a "permitted".

## Tests
21 geo/zoning tests pass (`tests/test_geospatial.py` 9, `tests/test_integration_zoning_intelligence.py` 12). The companion `ai/zoning-sources-mcp/` FastMCP server (8 keyless-source tools) has 4 passing tests.

Note: the typed spatial evidence is not yet promoted to the shared `runtime-contracts` package, and there is no geospatial mission in `agentic-os` yet — both are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)