### PR TITLE
ci: add secret-scan (gitleaks) — compliance hardening

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,30 @@
+name: secret-scan
+# Detects committed secrets with the gitleaks BINARY (free; no org license needed — the gitleaks Action
+# requires a paid license for organizations, the binary does not). --redact guarantees no secret VALUE is ever
+# printed in logs. Added by the compliance hardening pass as the plan-independent substitute for GitHub's
+# native secret scanning, which is a paid add-on on private repos. A failing run means a real secret is
+# committed: rotate it and purge it from history.
+on:
+  pull_request:
+  push:
+    branches: ["v4"]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks (redacted)
+        run: |
+          set -euo pipefail
+          ver="$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+                 | grep -oP '"tag_name": *"v\K[^"]+')"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${ver}/gitleaks_${ver}_linux_x64.tar.gz" \
+                 | tar -xz gitleaks
+          ./gitleaks detect --source . --redact --no-banner --exit-code 1


### PR DESCRIPTION
Adds a **secret-scan CI** (gitleaks binary, `--redact`) that flags committed secrets on PRs, weekly, and on demand — no secret value is ever printed.

This is the **plan-independent** fix for the compliance audit finding **SCM-SECRETSCAN-001**: it gives this repo secret detection for free, without GitHub Advanced Security (a paid add-on on private repos). The gitleaks *binary* is used deliberately — the gitleaks *Action* requires a paid license for orgs; the binary does not.

If the check fails on first run, a real secret is committed — rotate it and purge it from history.

Part of the estate-wide hardening pass (see the hardening report). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)