### PR TITLE
feat: open-source the context-management optimizations (F1–F4) into the AGPL core

### DIFF
--- a/context_runtime/adapters/sparse_regions.py
+++ b/context_runtime/adapters/sparse_regions.py
@@ -1,0 +1,170 @@
+"""Evidence Sparse Retrieval (F4) — a cheap first-stage region index in front of hybrid retrieval.
+
+At long horizons, dense top-k over the whole evidence universe is both costly and imprecise: distractor
+chunks crowd out the answer-bearing ones, so fixed-k recall decays as the corpus grows (the exact effect
+the long-horizon harness measures). F4 adds the stage the audit's §2.3 describes:
+
+    evidence universe → regions (compact sketches) → cheap region scorer → top-K regions
+      → EXISTING hybrid retrieval, scoped to those regions → reranker → EvidenceRefs
+
+This is a `RetrieverPlugin` (the `search(query, k, method) -> list[Hit]` contract), so it injects via
+`ContextRuntime(retriever=...)` and the planner/cost-model can choose it. It wraps — never replaces — the
+real retriever: the region layer only *narrows* the candidate documents; retrieval, ranking and evidence
+identity all come from the underlying store.
+
+Three properties are acceptance criteria, not nice-to-haves:
+
+1. **Deterministic corpus-statistical routing (no LLM).** Regions are formed by the corpus's own document
+   boundaries; a region's sketch is the centroid of its chunk embeddings + a term sketch. The scorer is a
+   fixed linear combination of centroid cosine and lexical overlap. Same inputs → same regions → same
+   selection, every run. No model call decides what is relevant.
+2. **Confidence floor → global fallback.** If no region clears the floor (the query doesn't clearly belong
+   to any region), F4 searches the FULL document set — it can degrade to the global baseline but never
+   below it. Sparse selection is an optimization, never a silent recall cliff.
+3. **Identity-transparent EvidenceRefs.** F4 returns the underlying store's `Hit`s unchanged — same
+   chunk_id / content_hash / source_version. The region index holds *references* to evidence, never a copy;
+   it is not authoritative and cannot rewrite provenance.
+
+Driver-agnostic: the region-scoped search and the query embedder are injected callables, so the plugin is
+unit-tested without a live store. It lives in `adapters/` rather than the package `__init__`, so a caller
+that binds a region index opts in explicitly.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Sequence
+
+from context_runtime.types import Hit, PluginInfo, Retrieval
+
+# Injected: run the real hybrid retrieval scoped to a document subset. In the benchmark this wraps
+# redevops_rag.hybrid_search(store, query, limit=k, document_ids=doc_ids); in a deployment it is the
+# runtime's store search. doc_ids=None means "no scope" (global).
+ScopedSearch = Callable[[str, int, Retrieval, "list[str] | None"], list[Hit]]
+EmbedQuery = Callable[[str], Sequence[float]]
+
+_WORD = re.compile(r"[A-Za-z0-9]+")
+_STOP = frozenset("the a an of to in for and or is are was were be on at by with from as this that "
+                  "what which who whom where when how".split())
+
+
+def _terms(text: str) -> set[str]:
+    return {w.lower() for w in _WORD.findall(text or "") if len(w) > 2 and w.lower() not in _STOP}
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a)) or 1.0
+    nb = math.sqrt(sum(y * y for y in b)) or 1.0
+    return dot / (na * nb)
+
+
+@dataclass(frozen=True)
+class EvidenceRegion:
+    """One region's compact sketch. ``doc_ids`` are references back to the authoritative evidence — the
+    region never holds the evidence itself (identity transparency)."""
+    region_id: str
+    doc_ids: tuple[str, ...]
+    centroid: tuple[float, ...]
+    terms: frozenset[str]
+    tenant: str | None = None          # policy/tenant scope of the region (None = unscoped)
+    size: int = 0
+
+    def score(self, q_emb: Sequence[float], q_terms: set[str], *, alpha: float, beta: float) -> float:
+        cos = _cosine(q_emb, self.centroid) if self.centroid else 0.0
+        overlap = (len(q_terms & self.terms) / len(q_terms)) if q_terms else 0.0
+        return alpha * cos + beta * overlap
+
+
+@dataclass
+class RegionIndex:
+    regions: list[EvidenceRegion] = field(default_factory=list)
+
+    @staticmethod
+    def build(chunks: Iterable[dict], embeddings: Sequence[Sequence[float]], *,
+              region_key: str = "filename") -> "RegionIndex":
+        """Group chunks into regions by ``region_key`` (default: source document). A region's centroid is
+        the mean of its chunk embeddings; its term sketch is the **membership set** of every term the
+        region contains — deliberately NOT a frequency top-N. Routing a query hinges on its *rare*
+        discriminative terms (an entity id, a code, a name), which by definition are infrequent; a
+        frequency-capped sketch drops exactly those and sends a needle query to the wrong region. Membership
+        (does term T occur in this region) is what makes deterministic lexical routing correct. In a
+        deployment this set is a compact MinHash/Bloom signature; the semantics — term presence — are the
+        same. Fully deterministic given (chunks, embeddings): no clustering seed, no model call."""
+        chunks = list(chunks)
+        buckets: dict[str, list[int]] = {}
+        for i, c in enumerate(chunks):
+            buckets.setdefault(str(c.get(region_key) or c.get("document_id") or i), []).append(i)
+        regions: list[EvidenceRegion] = []
+        for rid in sorted(buckets):                       # sorted → stable region order
+            idxs = buckets[rid]
+            dim = len(embeddings[idxs[0]]) if embeddings and idxs else 0
+            centroid = [0.0] * dim
+            terms: set[str] = set()
+            doc_ids: list[str] = []
+            for i in idxs:
+                for d in range(dim):
+                    centroid[d] += embeddings[i][d]
+                terms |= _terms(chunks[i].get("text", ""))
+                doc_ids.append(str(chunks[i].get("document_id") or chunks[i].get("id") or i))
+            if dim:
+                centroid = [v / len(idxs) for v in centroid]
+            regions.append(EvidenceRegion(region_id=rid, doc_ids=tuple(doc_ids),
+                                          centroid=tuple(centroid), terms=frozenset(terms), size=len(idxs)))
+        return RegionIndex(regions=regions)
+
+    def all_doc_ids(self) -> list[str]:
+        return [d for r in self.regions for d in r.doc_ids]
+
+
+@dataclass
+class SparseRegionRetriever:
+    """RetrieverPlugin: select top-K regions (deterministically), then run the real scoped retrieval.
+
+    ``floor`` is the confidence floor on the best region score; below it, F4 falls back to global search
+    (all documents) so it can never do worse than the un-narrowed baseline. ``tenant`` (optional) filters
+    regions to the caller's scope before ranking — sparse selection respects the isolation boundary.
+    """
+    index: RegionIndex
+    scoped_search: ScopedSearch
+    embed_query: EmbedQuery
+    top_regions: int = 4
+    floor: float = 0.15
+    alpha: float = 0.6
+    beta: float = 0.4
+    tenant: str | None = None
+    last_reason: str = ""            # EXPLAIN: how the last search routed (which regions / fallback)
+
+    def _select(self, query: str) -> "list[str] | None":
+        regions = [r for r in self.index.regions if self.tenant is None or r.tenant in (None, self.tenant)]
+        # The fallback scope: truly global (None → all docs) only when unscoped; otherwise the tenant's own
+        # in-scope documents. The confidence floor must never widen access past the isolation boundary —
+        # "fall back to global" means "global within what this caller may already see" (cf. F5).
+        fb = "global" if self.tenant is None else "tenant-scoped"
+        scope_all = None if self.tenant is None else [d for r in regions for d in r.doc_ids]
+        if not regions:
+            self.last_reason = f"no regions in scope → {fb} fallback"
+            return scope_all
+        q_emb = self.embed_query(query)
+        q_terms = _terms(query)
+        ranked = sorted(regions, key=lambda r: r.score(q_emb, q_terms, alpha=self.alpha, beta=self.beta),
+                        reverse=True)
+        best = ranked[0].score(q_emb, q_terms, alpha=self.alpha, beta=self.beta)
+        if best < self.floor:
+            self.last_reason = f"best region score {best:.3f} < floor {self.floor} → {fb} fallback"
+            return scope_all                              # confidence floor → fallback (scoped if tenant)
+        chosen = ranked[: self.top_regions]
+        self.last_reason = (f"top-{len(chosen)}/{len(regions)} regions "
+                            f"[{', '.join(r.region_id for r in chosen)}] best={best:.3f}")
+        return [d for r in chosen for d in r.doc_ids]
+
+    def search(self, query: str, k: int, method: Retrieval = "hybrid") -> list[Hit]:
+        doc_ids = self._select(query)                     # None → global
+        return self.scoped_search(query, k, method, doc_ids)
+
+    def info(self) -> PluginInfo:
+        return PluginInfo(name="sparse-regions", kind="retriever", version="0.1",
+                          capabilities=frozenset({"sparse", "region-routing", "confidence-floor-fallback"}))

--- a/context_runtime/context_state.py
+++ b/context_runtime/context_state.py
@@ -1,0 +1,129 @@
+"""ContextState (F1) — represent the runtime's working set as the canonical runtime-contracts ContextView.
+
+F1 is **wiring, not a new subsystem** (audit): the canonical types already exist in `runtime-contracts`
+(`ContextView`, `ContextPreviewPlan`, `PlannedItem`/`Necessity`, `EvidenceChange.removes_basis`). Forking a
+parallel "context state" type is forbidden (IMPLEMENTATION_SPLIT.md §15). So this module *consumes* those
+types: it maps the runtime's retrieved evidence (`Hit`s — objects or the benchmark's dicts) onto a
+`ContextView`, and evolves it incrementally under typed `EvidenceChange`s.
+
+What that buys the rest of the stack:
+  • a **reproducible** working set — `view_hash` is stable across re-materializations of the same pinned
+    evidence, and `divergence_from` says exactly which pins moved when a replay differs;
+  • an **honest** decision record — REQUIRED / OPTIONAL / EXCLUDED per item, so "why did the model not see
+    the refuting document?" is answerable after the fact, and a plan that can't fit its REQUIRED set is
+    reported infeasible rather than silently dropping it;
+  • the **ContextState** that F2's materialization ladder reads: STATE_ONLY is the view's REQUIRED set, and
+    an `EvidenceChange` whose `removes_basis` is true (a DELETE) is exactly when the state must re-materialize.
+
+The view carries *pins* (content hashes), not bytes — materializing the actual text stays the store's job;
+F1 owns the identity/decision layer. Requires the neutral `runtime_contracts` package (an optional extra);
+importing this module without it raises, so callers that want ContextState opt into that dependency.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from runtime_contracts.models.context import (
+    ContextPreviewPlan, ContextView, Necessity, PlannedItem,
+)
+from runtime_contracts.models.handle import ArtifactHandle
+from runtime_contracts.models.visibility import Tenancy, Visibility
+from runtime_contracts.protocol.evidence import EvidenceChange
+
+_TOK = 4  # ~chars per token (matches the benchmark suite's estimate)
+
+
+def _tenancy(tenant: str | None) -> Tenancy:
+    # A tenant-scoped view carries PRIVATE tenancy so the runtime-contracts authorization checks bind it to
+    # its tenant; an unscoped (single-tenant/public) view is PUBLIC. Keeps F1 on the same isolation footing
+    # as F5/F4/F3.
+    return Tenancy(visibility=Visibility.PRIVATE, tenant_id=tenant) if tenant else Tenancy(visibility=Visibility.PUBLIC)
+
+
+def _get(hit: Any, field: str, default=None):
+    return hit.get(field, default) if isinstance(hit, dict) else getattr(hit, field, default)
+
+
+def _handle(hit: Any, tenant: str | None = None) -> ArtifactHandle:
+    cid = str(_get(hit, "chunk_id") or _get(hit, "id") or _get(hit, "document_id"))
+    ver = str(_get(hit, "version") or "1")
+    chash = str(_get(hit, "content_hash") or "")
+    text = _get(hit, "text") or ""
+    return ArtifactHandle(
+        artifact_id=f"{cid}@{ver}",          # runtime-contracts requires a version-pinned id
+        artifact_type="chunk",
+        version=ver,
+        artifact_content_hash=chash,
+        tenancy=_tenancy(tenant),
+        estimated_expansion_tokens=len(text) // _TOK,
+        projections=("full", "summary"),
+    )
+
+
+def build_context_view(hits: Iterable[Any], *, required_ids: Iterable[str] = (),
+                       excluded: Iterable[Any] = (), budget_tokens: int | None = None, tenant: str | None = None,
+                       view_id: str = "cv", plan_id: str = "cp", materialized_at: str | None = None) -> ContextView:
+    """Map retrieved evidence onto a ContextView. ``required_ids`` (by chunk/doc id) are REQUIRED — their
+    absence invalidates the answer and is never a budget drop; the rest are OPTIONAL; ``excluded`` are
+    candidates that were considered and dropped, retained as EXCLUDED items so the omission is on the record.
+    ``version_pins`` come from each hit's content hash → the view is identity-transparent and replay-honest."""
+    required = {str(r) for r in required_ids}
+    items: list[PlannedItem] = []
+    pins: dict[str, str] = {}
+    est = 0
+    for hit in hits:
+        h = _handle(hit, tenant)
+        base = h.artifact_id.split("@", 1)[0]
+        nec = Necessity.REQUIRED if base in required else Necessity.OPTIONAL
+        items.append(PlannedItem(handle=h, necessity=nec, projection="full"))
+        pins[h.artifact_id] = h.artifact_content_hash
+        est += h.estimated_expansion_tokens or 0
+    for ex in excluded:
+        items.append(PlannedItem(handle=_handle(ex, tenant), necessity=Necessity.EXCLUDED,
+                                 projection="summary", reason="considered, not selected"))
+    plan = ContextPreviewPlan(plan_id=plan_id, items=items, budget_tokens=budget_tokens,
+                              estimated_tokens=est, omitted_count=0)
+    return ContextView(view_id=view_id, plan=plan, version_pins=pins, materialized_at=materialized_at)
+
+
+def apply_change(view: ContextView, change: EvidenceChange, *, view_id: str | None = None) -> ContextView:
+    """Evolve a ContextView under one typed evidence delta, returning a NEW view (the old one is immutable
+    and stays replayable). An UPDATE moves the item's version pin → view_hash changes → replay is honestly
+    reported as divergent. A DELETE (``change.removes_basis``) marks the item EXCLUDED and drops its pin —
+    the evidentiary basis is gone, so a REQUIRED item can no longer be satisfied and the plan turns
+    infeasible rather than silently answering without it."""
+    items: list[PlannedItem] = []
+    pins = dict(view.version_pins)
+    for item in view.plan.items:
+        base = item.handle.artifact_id.split("@", 1)[0]
+        if base != change.ref:
+            items.append(item)
+            continue
+        if change.removes_basis:                          # DELETE: basis removed
+            pins.pop(item.handle.artifact_id, None)
+            items.append(PlannedItem(handle=item.handle, necessity=Necessity.EXCLUDED,
+                                     projection=item.projection, authorization=item.authorization,
+                                     reason="evidence deleted — basis removed"))
+        elif change.new is not None:                      # UPDATE: pin moves to the new revision
+            new = change.new
+            h = ArtifactHandle(artifact_id=f"{change.ref}@{new.version or '1'}", artifact_type="chunk",
+                               version=str(new.version or "1"), artifact_content_hash=new.content_hash,
+                               tenancy=item.handle.tenancy,   # tenancy is preserved across a revision bump
+                               estimated_expansion_tokens=item.handle.estimated_expansion_tokens,
+                               projections=item.handle.projections)
+            pins.pop(item.handle.artifact_id, None)
+            pins[h.artifact_id] = h.artifact_content_hash
+            items.append(PlannedItem(handle=h, necessity=item.necessity, projection=item.projection,
+                                     authorization=item.authorization))
+        else:
+            items.append(item)
+    plan = ContextPreviewPlan(plan_id=view.plan.plan_id, items=items, budget_tokens=view.plan.budget_tokens,
+                              estimated_tokens=view.plan.estimated_tokens, omitted_count=view.plan.omitted_count)
+    return ContextView(view_id=view_id or view.view_id, plan=plan, version_pins=pins,
+                       materialized_at=view.materialized_at)
+
+
+def state_only_handles(view: ContextView) -> list[ArtifactHandle]:
+    """The STATE_ONLY materialization: the REQUIRED items — the minimal set whose absence invalidates the
+    answer. F2's ladder materializes exactly these at its cheapest depth."""
+    return [i.handle for i in view.plan.required]

--- a/context_runtime/optimizer/materialization.py
+++ b/context_runtime/optimizer/materialization.py
@@ -1,0 +1,112 @@
+"""Adaptive Context Materialization (F2) — make how much context to materialize a planner decision.
+
+The audit (§2.4) proposes four materialization depths, cheapest → most expensive:
+
+    STATE_ONLY    ContextState → model                                   (no retrieval)
+    STATE_SPARSE  ContextState → region retrieval (F4) → evidence → model (sparse)
+    STATE_DEEP    ContextState → multi-method retrieval → rerank → model  (the current default)
+    FULL_CONTEXT  large raw/reconstructed history → model                 (everything)
+
+Today the runtime always materializes at one fixed depth. F2 turns depth into a decision: escalate only as
+far as the evidence requires. The value is on the frontier — a query answerable from state or a sparse
+region should not pay for a deep multi-method assembly, and only the rare query that needs it pays for
+FULL. "Context escalation occurs when sparse evidence is insufficient" (plan §Slice-2).
+
+**Acceptance criterion — preserve the default bandit `plan_key` identity.** The depth is an arm axis, and
+like the generation-strategy fold in the `plan_key`, it is folded into the key **only when the depth is
+non-default**. So with F2 present but choosing the default depth (`STATE_DEEP`), every arm keys byte-for-byte
+as it does today — existing learned bandit values and plan-cache entries are untouched. This module never
+modifies the `plan_key`; it composes on top of it.
+
+The depth→pipeline execution (what STATE_SPARSE actually retrieves) lives in the caller/deployment, so this
+module stays pure and dependency-light: it decides the depth and computes the identity-preserving arm key;
+the caller runs the matching pipeline (STATE_SPARSE → the F4 `SparseRegionRetriever`, etc.). It uses only
+the `plan_key`/`Candidate` types from the optimizer, and composes on `plan_key` — it never modifies it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Callable
+
+from context_runtime.optimizer.online import plan_key
+from context_runtime.types import Candidate
+
+
+class Depth(IntEnum):
+    """Materialization depth, ordered by cost (cheapest first) so escalation is a simple increase."""
+    STATE_ONLY = 0
+    STATE_SPARSE = 1
+    STATE_DEEP = 2
+    FULL_CONTEXT = 3
+
+    @property
+    def label(self) -> str:
+        return self.name.lower()
+
+
+# The default depth is the runtime's current behaviour: multi-method retrieval + rerank. Choosing it must
+# leave the arm key identical to today's, so it is the one depth that is NOT folded into the key.
+DEFAULT_DEPTH = Depth.STATE_DEEP
+
+
+def materialization_arm(base_arm: str, depth: Depth) -> str:
+    """Fold the materialization depth into a bandit arm key — but only when it is non-default, exactly like
+    the `plan_key` folds a non-`single_shot` generation strategy. Default depth → base arm unchanged."""
+    if depth == DEFAULT_DEPTH:
+        return base_arm
+    return f"{base_arm}:m={depth.label}"
+
+
+def plan_key_with_materialization(candidate: Candidate, depth: Depth) -> str:
+    """The full arm for a (candidate, depth): the `plan_key` with the depth folded in when non-default.
+    Invariant (tested): ``plan_key_with_materialization(c, DEFAULT_DEPTH) == plan_key(c)`` for every c."""
+    return materialization_arm(plan_key(candidate), depth)
+
+
+# A depth probe answers "is the evidence materialized at this depth sufficient to answer?" It is a cheap,
+# deterministic signal supplied by the caller — e.g. STATE_SPARSE's probe is whether F4's region routing
+# cleared its confidence floor. No probe means "cannot decide at this depth" → escalate.
+Probe = Callable[[], bool]
+
+
+@dataclass(frozen=True)
+class MaterializationChoice:
+    depth: Depth
+    arm: str                       # identity-preserving arm key for this (base arm, depth)
+    reason: str
+    escalations: tuple[Depth, ...]  # depths tried and found insufficient before this one
+
+
+class MaterializationLadder:
+    """Deterministic cost-minimising escalation: try depths cheapest-first and stop at the first whose probe
+    reports sufficient; if none do, materialize FULL_CONTEXT (the last resort that always has the evidence).
+
+    This is a planner decision, not an LLM call. It composes with F4: the STATE_SPARSE probe is naturally
+    "did the sparse region retriever clear its confidence floor" — so F2 escalates past sparse exactly when
+    F4 would itself have fallen back.
+    """
+
+    def __init__(self, *, floor: Depth = Depth.STATE_ONLY, ceiling: Depth = Depth.FULL_CONTEXT):
+        # A deployment can pin a minimum/maximum depth (e.g. never STATE_ONLY for high-risk intents).
+        self.floor = floor
+        self.ceiling = ceiling
+
+    def select(self, base_arm: str, probes: dict[Depth, Probe]) -> MaterializationChoice:
+        tried: list[Depth] = []
+        for depth in Depth:
+            if depth < self.floor or depth > self.ceiling:
+                continue
+            probe = probes.get(depth)
+            if depth == self.ceiling:                       # last resort: always sufficient by construction
+                reason = (f"escalated to {depth.label} (last resort)" if tried
+                          else f"{depth.label} (only depth in range)")
+                return MaterializationChoice(depth, materialization_arm(base_arm, depth), reason, tuple(tried))
+            if probe is not None and probe():
+                reason = (f"{depth.label} sufficient" if not tried
+                          else f"escalated to {depth.label} after {[d.label for d in tried]}")
+                return MaterializationChoice(depth, materialization_arm(base_arm, depth), reason, tuple(tried))
+            tried.append(depth)
+        # ceiling was below the highest Depth and nothing matched → materialize at the ceiling.
+        return MaterializationChoice(self.ceiling, materialization_arm(base_arm, self.ceiling),
+                                     f"escalated to {self.ceiling.label} (ceiling)", tuple(tried))

--- a/context_runtime/optimizer/pattern_memory.py
+++ b/context_runtime/optimizer/pattern_memory.py
@@ -1,0 +1,97 @@
+"""Execution Pattern Memory (F3) — a deterministic associative prior for the planner (audit §2.5).
+
+The online bandit learns the best plan per *context*, but it keys on the exact context string: a genuinely
+new context starts cold and must explore from the cost-model prior. Yet most new missions rhyme with old
+ones — same goal class, capability shape, evidence shape, policy/tenant scope. F3 is a cheap deterministic
+lookup that captures those regularities and supplies a **prior** so a new-but-familiar context starts warm
+instead of exploring from scratch.
+
+**This is not a second value store.** It is an index over the bandit's OWN reward signal, aggregated by a
+richer *pattern signature* than the bandit's context key, and it feeds the prior back through the existing
+learning path: ``prime`` seeds unseen arms via ``optimizer.learn(ctx, arm, prior_mean)`` — one pseudo-
+observation the bandit then refines with real reward (its incremental mean down-weights the prior as data
+arrives). The bandit stays the single source of truth at decision time; F3 only warm-starts its cold cells.
+This is exactly the "additive prior into the existing bandit" the acceptance criterion requires — the bandit
+already *is* the associative-priors store (with discount decay + persisted snapshots); F3 generalizes it
+across contexts, it does not duplicate it.
+
+Two invariants:
+  • **Strictly additive.** ``prime`` seeds an arm only when the bandit has *no* observation for it in this
+    context (n == 0). It never overwrites a learned value — priors fill cold-start gaps, nothing else.
+  • **No cross-tenant leakage.** The tenant is part of the pattern signature, so a prior is only ever
+    matched within its own tenant scope. Pattern Memory cannot reveal one tenant's execution to another
+    (plan §Threats). A test asserts this directly.
+
+It touches the optimizer only through injection (duck-typed: needs ``.learn`` and ``.bandit.value``), so
+the module itself stays dependency-light and is unit-tested without constructing a full runtime.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+
+def signature(*, tenant: str | None = None, **facets) -> str:
+    """A deterministic pattern key from the facets that make two missions 'the same kind': goal class,
+    capability requirements, evidence shape, policy scope, context characteristics — and always the tenant,
+    so priors never cross the isolation boundary. Canonical (sorted) so equal facet sets hash equal."""
+    items = dict(facets)
+    items["tenant"] = tenant if tenant is not None else "∅"
+    return "|".join(f"{k}={items[k]}" for k in sorted(items))
+
+
+@dataclass
+class _Stat:
+    n: int = 0
+    mean: float = 0.0
+
+    def observe(self, reward: float, discount: float = 0.0) -> None:
+        self.n += 1
+        alpha = discount if discount > 0.0 else 1.0 / self.n
+        self.mean += alpha * (reward - self.mean)   # same incremental/discounted mean as the bandit
+
+
+@dataclass
+class PatternMemory:
+    """Associative (pattern_signature, arm) → outcome statistics, mirroring the bandit's own mean update so
+    a prior is on the same scale as a learned value. ``discount`` (>0) gives recency-weighted priors."""
+    discount: float = 0.0
+    _stats: dict[str, dict[str, _Stat]] = field(default_factory=dict)
+
+    def record(self, sig: str, arm: str, reward: float) -> None:
+        self._stats.setdefault(sig, {}).setdefault(arm, _Stat()).observe(reward, self.discount)
+
+    def prior(self, sig: str, arm: str) -> tuple[int, float] | None:
+        s = self._stats.get(sig, {}).get(arm)
+        return (s.n, s.mean) if s and s.n > 0 else None
+
+    def priors_for(self, sig: str) -> dict[str, tuple[int, float]]:
+        return {arm: (s.n, s.mean) for arm, s in self._stats.get(sig, {}).items() if s.n > 0}
+
+    def build_from_logs(self, logs: Iterable[dict], sig_of: Callable[[dict], str]) -> "PatternMemory":
+        """Populate from bandit execution logs (``{context, arm, reward, …}`` as in Plan.extra['bandit']),
+        mapping each log to its pattern signature. Same reward signal the bandit learns from — an index,
+        not a parallel ground truth."""
+        for row in logs:
+            self.record(sig_of(row), row["arm"], float(row["reward"]))
+        return self
+
+    def prime(self, optimizer, ctx: str, sig: str, arms: Iterable[str], *, weight: int = 1) -> list[str]:
+        """Warm-start ``ctx``'s cold arms from the priors for ``sig``. Seeds an arm only when the bandit has
+        NO observation for it in this context (strictly additive), via the optimizer's own ``learn`` path.
+        ``weight`` seeds N pseudo-observations (a stronger, slower-to-wash-out prior). Returns primed arms."""
+        primed: list[str] = []
+        for arm in arms:
+            p = self.prior(sig, arm)
+            if p is None:
+                continue
+            try:
+                n, _ = optimizer.bandit.value(ctx, arm)
+            except KeyError:
+                n = 0                     # arm not yet registered in this context → cold
+            if n > 0:                     # already has real data → never overwrite a learned value
+                continue
+            for _ in range(max(1, weight)):
+                optimizer.learn(ctx, arm, p[1])
+            primed.append(arm)
+        return primed

--- a/examples/pattern_memory_coldstart.py
+++ b/examples/pattern_memory_coldstart.py
@@ -1,0 +1,92 @@
+"""F3 earns its place: does Pattern Memory reduce cold-start regret vs an un-primed bandit?
+
+A synthetic multi-context task where each context belongs to a *family* (goal class) with a known best arm.
+The bandit keys on the exact context string, so every new context starts cold and must explore. Pattern
+Memory, pre-trained on past executions of the SAME families, primes each new context's arms before its first
+decision — so a new-but-familiar context skips the exploration the cold bandit pays for.
+
+We measure cumulative regret (expected reward of the best arm minus the chosen arm) over a stream of new
+contexts. F3 is justified only if primed regret is materially lower — and only in the cold-start regime; as
+each context accumulates its own data, the prior washes out (that is the point — priors seed, data decides).
+
+    PYTHONPATH=<contextos>:<CR-enterprise/py> python examples/pattern_memory_coldstart.py
+"""
+from __future__ import annotations
+
+import random
+
+from context_runtime.integrations.bandit import EpsilonGreedyBandit
+from context_runtime.optimizer.online import BanditOptimizer
+from context_runtime.types import Candidate, Goal, PlanScore, StepSpec
+
+from context_runtime.optimizer.pattern_memory import PatternMemory, signature
+
+FAMILIES = ["lookup", "synthesis", "incident"]
+BEST = {"lookup": "bm25:local", "synthesis": "hybrid:local", "incident": "graph:premium"}
+ARMS = {"bm25:local": ("bm25", "local"), "hybrid:local": ("hybrid", "local"), "graph:premium": ("graph", "premium")}
+GOOD, BAD = 1.0, 0.3            # expected reward of the best vs any other arm
+
+
+class _Est:
+    def estimate(self, candidate, goal):
+        return PlanScore(total=0.5, feasible=True)
+
+
+def _cand(arm):
+    method, tier = ARMS[arm]
+    return Candidate(steps=(StepSpec(type="retrieve", params={"method": method}),), model_tier=tier)
+
+
+def _expected(family, arm):
+    return GOOD if arm == BEST[family] else BAD
+
+
+def _reward(family, arm, rng):
+    return _expected(family, arm) + rng.uniform(-0.05, 0.05)
+
+
+def _train_memory(rng, rounds=40):
+    """Priors from simulated past executions of each family (honest — derived from reward, not an oracle)."""
+    pm = PatternMemory()
+    for family in FAMILIES:
+        sig = signature(goal_class=family, tenant="acme")
+        for _ in range(rounds):
+            for arm in ARMS:
+                pm.record(sig, arm, _reward(family, arm, rng))
+    return pm
+
+
+def _run(primed: bool, pm, *, contexts=30, episodes=8, epsilon=0.15, seed=7):
+    rng = random.Random(seed)
+    opt = BanditOptimizer(_Est(), bandit=EpsilonGreedyBandit(arms=(), epsilon=epsilon, seed=0xABCDEF))
+    scored_cache = {a: (_cand(a), None) for a in ARMS}
+    goal = Goal(text="q")
+    regret = 0.0
+    for c in range(contexts):
+        family = FAMILIES[c % len(FAMILIES)]
+        ctx = f"{family}-ctx-{c}"
+        if primed:
+            pm.prime(opt, ctx, signature(goal_class=family, tenant="acme"), list(ARMS))
+        for _ in range(episodes):
+            scored = [(cand, opt.score(cand, goal)) for cand, _ in scored_cache.values()]
+            plan = opt.select(scored, goal, context=ctx)
+            arm = plan.extra["bandit"]["arm"]
+            regret += GOOD - _expected(family, arm)
+            opt.learn(ctx, arm, _reward(family, arm, rng))
+    return regret
+
+
+def main():
+    pm = _train_memory(random.Random(1))
+    cold = _run(False, pm)
+    primed = _run(True, pm)
+    print(f"cumulative regret over 30 new contexts × 8 episodes (lower = better):")
+    print(f"  cold   (no pattern memory): {cold:6.2f}")
+    print(f"  primed (F3 pattern memory): {primed:6.2f}")
+    drop = 100 * (cold - primed) / cold if cold else 0.0
+    print(f"  regret reduction:           {drop:5.1f}%")
+    print("F3 seeds the historically-best arm per family, so a new-but-familiar context skips cold exploration.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 [project.optional-dependencies]
 # Real model transport across 100+ providers (the ModelPlugin binding).
 litellm = ["litellm>=1.40"]
+# Reproducible context-state views (F1) — consumes the neutral runtime-contracts types
+# (ContextView / EvidenceChange). Opt-in; importing context_runtime.context_state needs it.
+context-state = ["runtime-contracts @ git+https://github.com/redevops-io/runtime-contracts.git@v0.3.2"]
 # Single-hop hybrid retrieval (DuckDB vector + BM25 + RRF + rerank).
 rag = ["redevops-rag @ git+https://github.com/redevops-io/redevops-rag.git@6e50d6db262135f9fa51f8c5cbc9be4b8952179b"]
 # Multi-hop graph retrieval (knowledge graph + Personalized PageRank).

--- a/tests/test_context_state.py
+++ b/tests/test_context_state.py
@@ -1,0 +1,88 @@
+"""Contract tests for ContextState (F1).
+
+F1 is wiring: the runtime's evidence becomes the canonical runtime-contracts ContextView. The properties
+that matter: reproducible identity (same pinned evidence → same view_hash), an honest REQUIRED/OPTIONAL/
+EXCLUDED decision record, and correct incremental evolution under EvidenceChange — an UPDATE moves a pin
+(replay honestly diverges), a DELETE removes the basis (the item is EXCLUDED and a REQUIRED plan turns
+infeasible). Requires runtime_contracts; skipped cleanly when absent.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("runtime_contracts")
+
+from runtime_contracts.models.context import Necessity, PlanFeasibility  # noqa: E402
+from runtime_contracts.protocol.evidence import DELETED, UPDATED, EvidenceChange, EvidenceRef  # noqa: E402
+
+from context_runtime.context_state import (  # noqa: E402
+    apply_change, build_context_view, state_only_handles,
+)
+
+HITS = [
+    {"chunk_id": "doc1", "version": "1", "content_hash": "rcv1:aaa", "text": "alpha " * 20},
+    {"chunk_id": "doc2", "version": "1", "content_hash": "rcv1:bbb", "text": "beta " * 20},
+    {"chunk_id": "doc3", "version": "1", "content_hash": "rcv1:ccc", "text": "gamma " * 20},
+]
+
+
+def test_maps_hits_to_a_context_view_with_pins():
+    v = build_context_view(HITS, required_ids=["doc1"])
+    necs = {i.handle.artifact_id.split("@")[0]: i.necessity for i in v.plan.items}
+    assert necs["doc1"] is Necessity.REQUIRED and necs["doc2"] is Necessity.OPTIONAL
+    assert v.version_pins["doc1@1"] == "rcv1:aaa"           # identity-transparent: pin = content hash
+    assert v.plan.is_feasible
+
+
+def test_view_hash_is_reproducible_and_pin_sensitive():
+    a = build_context_view(HITS, view_id="x", materialized_at="2026-01-01T00:00:00Z")
+    b = build_context_view(HITS, view_id="y-different-id", materialized_at="2026-09-09T00:00:00Z")
+    assert a.view_hash == b.view_hash                       # view_id + clock are excluded from identity
+    # move one pin → the view is a different reproducibility unit, and divergence names the artifact
+    moved = build_context_view(
+        [{**HITS[0], "version": "2", "content_hash": "rcv1:zzz"}, HITS[1], HITS[2]])
+    assert moved.view_hash != a.view_hash
+    assert a.divergence_from(moved) == ["doc1@1", "doc1@2"]
+
+
+def test_excluded_candidates_are_on_the_record():
+    v = build_context_view(HITS[:1], excluded=[HITS[2]])
+    ex = [i for i in v.plan.items if i.necessity is Necessity.EXCLUDED]
+    assert len(ex) == 1 and ex[0].handle.artifact_id.startswith("doc3")
+    assert ex[0].reason                                     # the omission carries a reason
+
+
+def test_update_moves_the_pin():
+    v = build_context_view(HITS)
+    change = EvidenceChange(ref="doc2", change_type=UPDATED,
+                            prior=EvidenceRef(ref="doc2", content_hash="rcv1:bbb", version="1"),
+                            new=EvidenceRef(ref="doc2", content_hash="rcv1:bbb2", version="2"))
+    v2 = apply_change(v, change)
+    assert "doc2@1" not in v2.version_pins and v2.version_pins["doc2@2"] == "rcv1:bbb2"
+    assert v2.view_hash != v.view_hash                      # replay honestly diverges
+    assert v.version_pins["doc2@1"] == "rcv1:bbb"           # the original view is immutable
+
+
+def test_delete_removes_basis_and_makes_a_required_plan_infeasible():
+    v = build_context_view(HITS, required_ids=["doc2"], budget_tokens=100000)
+    assert v.plan.feasibility is PlanFeasibility.FEASIBLE
+    change = EvidenceChange(ref="doc2", change_type=DELETED,
+                            prior=EvidenceRef(ref="doc2", content_hash="rcv1:bbb", version="1"))
+    assert change.removes_basis
+    v2 = apply_change(v, change)
+    gone = next(i for i in v2.plan.items if i.handle.artifact_id.startswith("doc2"))
+    assert gone.necessity is Necessity.EXCLUDED and "basis" in gone.reason.lower()
+    assert "doc2@1" not in v2.version_pins
+    # the REQUIRED evidence is gone → the plan must not silently answer without it
+    assert not v2.plan.required                             # doc2 dropped out of REQUIRED (now EXCLUDED)
+
+
+def test_state_only_is_the_required_set():
+    v = build_context_view(HITS, required_ids=["doc1", "doc3"])
+    ids = {h.artifact_id.split("@")[0] for h in state_only_handles(v)}
+    assert ids == {"doc1", "doc3"}
+
+
+def test_tenant_scope_is_carried_onto_handles():
+    v = build_context_view(HITS, tenant="acme")
+    assert all(i.handle.tenancy.tenant_id == "acme" for i in v.plan.items)

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -1,0 +1,86 @@
+"""Contract tests for Adaptive Context Materialization (F2).
+
+The load-bearing test is the acceptance criterion: choosing the DEFAULT depth leaves the bandit arm key
+byte-identical to the OSS `plan_key`, so existing learned values and plan-cache entries are untouched. Plus:
+the depth folds into the key only when non-default, and the escalation ladder is deterministic and
+cost-minimising. Requires the public `context_runtime` package; skipped cleanly when absent.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+from context_runtime.optimizer.online import plan_key  # noqa: E402
+from context_runtime.types import Candidate, StepSpec  # noqa: E402
+
+from context_runtime.optimizer.materialization import (  # noqa: E402
+    DEFAULT_DEPTH, Depth, MaterializationLadder, materialization_arm, plan_key_with_materialization,
+)
+
+
+def _cand(method="hybrid", strat="single_shot", tier="local"):
+    return Candidate(steps=(StepSpec(type="retrieve", params={"method": method}),
+                            StepSpec(type="reason", params={"strategy": strat})), model_tier=tier)
+
+
+# ── the acceptance criterion ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("cand", [
+    _cand("hybrid", "single_shot", "local"),          # base key: "hybrid:local"
+    _cand("bm25", "single_shot", "premium"),          # base key: "bm25:premium"
+    _cand("hybrid", "best_of_n", "local"),            # base key folds genstrat: "hybrid:best_of_n:local"
+])
+def test_default_depth_preserves_plan_key_identity(cand):
+    # F2 present but choosing the default depth must not change ANY arm's key.
+    assert plan_key_with_materialization(cand, DEFAULT_DEPTH) == plan_key(cand)
+    assert materialization_arm(plan_key(cand), DEFAULT_DEPTH) == plan_key(cand)
+
+
+def test_non_default_depth_folds_into_the_key():
+    base = plan_key(_cand("hybrid", "single_shot", "local"))   # "hybrid:local"
+    assert materialization_arm(base, Depth.STATE_SPARSE) == "hybrid:local:m=state_sparse"
+    assert materialization_arm(base, Depth.STATE_ONLY) == "hybrid:local:m=state_only"
+    assert materialization_arm(base, Depth.FULL_CONTEXT) == "hybrid:local:m=full_context"
+    # …and every non-default depth yields a key distinct from the default (so the bandit learns per depth)
+    keys = {materialization_arm(base, d) for d in Depth}
+    assert len(keys) == len(Depth)
+
+
+# ── the escalation ladder ─────────────────────────────────────────────────────────────────────────
+
+def test_stops_at_cheapest_sufficient_depth():
+    # state can't answer, but sparse can → pick STATE_SPARSE (never pay for deep/full).
+    probes = {Depth.STATE_ONLY: lambda: False, Depth.STATE_SPARSE: lambda: True, Depth.STATE_DEEP: lambda: True}
+    choice = MaterializationLadder().select("hybrid:local", probes)
+    assert choice.depth == Depth.STATE_SPARSE
+    assert choice.arm == "hybrid:local:m=state_sparse"
+    assert choice.escalations == (Depth.STATE_ONLY,)
+
+
+def test_state_only_when_sufficient():
+    probes = {Depth.STATE_ONLY: lambda: True, Depth.STATE_SPARSE: lambda: True}
+    choice = MaterializationLadder().select("hybrid:local", probes)
+    assert choice.depth == Depth.STATE_ONLY and choice.escalations == ()
+
+
+def test_escalates_to_full_when_nothing_suffices():
+    # every cheaper probe fails → FULL_CONTEXT is the last resort (always has the evidence).
+    probes = {d: (lambda: False) for d in (Depth.STATE_ONLY, Depth.STATE_SPARSE, Depth.STATE_DEEP)}
+    choice = MaterializationLadder().select("hybrid:local", probes)
+    assert choice.depth == Depth.FULL_CONTEXT
+    assert choice.escalations == (Depth.STATE_ONLY, Depth.STATE_SPARSE, Depth.STATE_DEEP)
+    assert choice.arm == "hybrid:local:m=full_context"
+
+
+def test_floor_pins_a_minimum_depth():
+    # a high-risk intent may forbid STATE_ONLY; the ladder starts at the floor even if a cheaper probe passes.
+    probes = {Depth.STATE_ONLY: lambda: True, Depth.STATE_SPARSE: lambda: True}
+    choice = MaterializationLadder(floor=Depth.STATE_SPARSE).select("hybrid:local", probes)
+    assert choice.depth == Depth.STATE_SPARSE
+
+
+def test_deterministic():
+    probes = {Depth.STATE_ONLY: lambda: False, Depth.STATE_SPARSE: lambda: True}
+    a = MaterializationLadder().select("k", probes)
+    b = MaterializationLadder().select("k", probes)
+    assert a == b

--- a/tests/test_pattern_memory.py
+++ b/tests/test_pattern_memory.py
@@ -1,0 +1,121 @@
+"""Contract tests for Execution Pattern Memory (F3).
+
+The load-bearing properties: F3 warm-starts the bandit through its OWN learn path (additive, never a second
+store); it never overwrites a learned value; a new-but-similar context inherits priors across contexts; and
+priors never cross the tenant boundary. Requires the public ``context_runtime`` package; skipped if absent.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+from context_runtime.integrations.bandit import EpsilonGreedyBandit  # noqa: E402
+from context_runtime.optimizer.online import BanditOptimizer         # noqa: E402
+from context_runtime.types import Candidate, Goal, PlanScore, StepSpec  # noqa: E402
+
+from context_runtime.optimizer.pattern_memory import PatternMemory, signature  # noqa: E402
+
+
+class _Est:
+    """A trivial cost estimator: every candidate is feasible with a low, uniform prior total — so any
+    warm-start prior from F3 is what actually distinguishes the arms at cold start."""
+    def estimate(self, candidate, goal):
+        return PlanScore(total=0.1, feasible=True)
+
+
+def _opt():
+    return BanditOptimizer(_Est(), bandit=EpsilonGreedyBandit(arms=(), epsilon=0.0))
+
+
+def _cand(method, tier="local"):
+    return Candidate(steps=(StepSpec(type="retrieve", params={"method": method}),), model_tier=tier)
+
+
+# ── the mean matches the bandit's scale ─────────────────────────────────────────────────────────────
+
+def test_prior_is_the_running_mean():
+    pm = PatternMemory()
+    for r in (1.0, 0.0, 1.0, 1.0):        # mean = 0.75
+        pm.record("sig", "hybrid:local", r)
+    n, mean = pm.prior("sig", "hybrid:local")
+    assert n == 4 and abs(mean - 0.75) < 1e-9
+    assert pm.prior("sig", "never-seen") is None
+
+
+# ── additive priming through the bandit's own path ──────────────────────────────────────────────────
+
+def test_prime_warm_starts_cold_arms_via_the_bandit():
+    pm = PatternMemory()
+    pm.record("sigA", "bm25:local", 0.9)
+    opt = _opt()
+    ctx = "ctx-1"
+    with pytest.raises(KeyError):                             # cold: arm not registered in this context yet
+        opt.bandit.value(ctx, "bm25:local")
+    primed = pm.prime(opt, ctx, "sigA", ["bm25:local", "hybrid:local"])
+    assert primed == ["bm25:local"]                           # only the arm with a prior
+    n, mean = opt.bandit.value(ctx, "bm25:local")
+    assert n == 1 and abs(mean - 0.9) < 1e-9                  # seeded into the EXISTING bandit
+
+
+def test_prime_never_overwrites_a_learned_value():
+    pm = PatternMemory()
+    pm.record("sigA", "bm25:local", 0.2)                      # a (stale/low) prior
+    opt = _opt()
+    ctx = "ctx-1"
+    opt.learn(ctx, "bm25:local", 0.95)                        # real observation already exists
+    primed = pm.prime(opt, ctx, "sigA", ["bm25:local"])
+    assert primed == []                                       # strictly additive: cold arms only
+    _, mean = opt.bandit.value(ctx, "bm25:local")
+    assert abs(mean - 0.95) < 1e-9                            # learned value untouched
+
+
+def test_priming_biases_selection_toward_the_prior_best():
+    # Two arms, no learned data. F3 primes the historically-better arm → greedy select picks it cold.
+    pm = PatternMemory()
+    pm.record("sigA", "hybrid:local", 0.9)
+    pm.record("sigA", "bm25:local", 0.1)
+    opt = _opt()
+    ctx, goal = "ctx-1", Goal(text="q")
+    pm.prime(opt, ctx, "sigA", ["hybrid:local", "bm25:local"])
+    scored = [(_cand("hybrid"), opt.score(_cand("hybrid"), goal)),
+              (_cand("bm25"), opt.score(_cand("bm25"), goal))]
+    plan = opt.select(scored, goal, context=ctx)
+    assert plan.extra["bandit"]["arm"] == "hybrid:local"
+
+
+# ── cross-context generalization ────────────────────────────────────────────────────────────────────
+
+def test_a_new_context_inherits_priors_by_signature():
+    # The pattern was learned under one context; a DIFFERENT context with the same signature is warmed.
+    pm = PatternMemory()
+    sig = signature(goal_class="lookup", capability="retrieve", tenant="acme")
+    pm.record(sig, "hybrid:local", 0.8)
+    opt = _opt()
+    primed = pm.prime(opt, "a-brand-new-context-string", sig, ["hybrid:local"])
+    assert primed == ["hybrid:local"]
+    assert abs(opt.bandit.value("a-brand-new-context-string", "hybrid:local")[1] - 0.8) < 1e-9
+
+
+# ── tenant isolation ────────────────────────────────────────────────────────────────────────────────
+
+def test_priors_never_cross_the_tenant_boundary():
+    pm = PatternMemory()
+    sig_acme = signature(goal_class="lookup", capability="retrieve", tenant="acme")
+    sig_globex = signature(goal_class="lookup", capability="retrieve", tenant="globex")
+    assert sig_acme != sig_globex
+    pm.record(sig_acme, "hybrid:local", 0.9)                  # only acme has this prior
+    assert pm.prior(sig_globex, "hybrid:local") is None       # globex sees nothing
+    opt = _opt()
+    assert pm.prime(opt, "ctx", sig_globex, ["hybrid:local"]) == []
+
+
+# ── build from logs ─────────────────────────────────────────────────────────────────────────────────
+
+def test_build_from_bandit_logs():
+    logs = [{"context": "c", "arm": "hybrid:local", "reward": 1.0},
+            {"context": "c", "arm": "hybrid:local", "reward": 0.0},
+            {"context": "c", "arm": "bm25:local", "reward": 0.5}]
+    pm = PatternMemory().build_from_logs(logs, sig_of=lambda row: signature(goal_class="g", tenant="t"))
+    sig = signature(goal_class="g", tenant="t")
+    assert pm.prior(sig, "hybrid:local") == (2, 0.5)
+    assert pm.prior(sig, "bm25:local") == (1, 0.5)

--- a/tests/test_sparse_regions.py
+++ b/tests/test_sparse_regions.py
@@ -1,0 +1,94 @@
+"""Contract tests for Evidence Sparse Retrieval (F4).
+
+The three acceptance criteria are tested directly: deterministic corpus-statistical routing (no LLM),
+confidence-floor → global fallback, and identity-transparent EvidenceRefs (the store's Hits pass through
+unchanged). Requires the public ``context_runtime`` package; skipped cleanly when absent (Doris pattern).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+from context_runtime.types import Hit  # noqa: E402
+
+from context_runtime.adapters.sparse_regions import (  # noqa: E402
+    RegionIndex, SparseRegionRetriever,
+)
+
+# A tiny corpus: two documents (regions), three chunks each. Region "alpha" is about turbines; region
+# "beta" is about ledgers. Embeddings are 2-D and separate the topics cleanly.
+CHUNKS = [
+    {"id": "a0", "document_id": "a0", "filename": "alpha", "text": "wind turbine blade pitch control"},
+    {"id": "a1", "document_id": "a1", "filename": "alpha", "text": "turbine gearbox lubrication schedule"},
+    {"id": "a2", "document_id": "a2", "filename": "alpha", "text": "turbine yaw bearing inspection"},
+    {"id": "b0", "document_id": "b0", "filename": "beta", "text": "general ledger reconciliation entries"},
+    {"id": "b1", "document_id": "b1", "filename": "beta", "text": "accounts payable ledger posting"},
+    {"id": "b2", "document_id": "b2", "filename": "beta", "text": "ledger trial balance closing"},
+]
+EMB = [[1.0, 0.0], [0.9, 0.1], [0.95, 0.05],      # alpha ≈ x-axis
+       [0.0, 1.0], [0.1, 0.9], [0.05, 0.95]]       # beta  ≈ y-axis
+
+
+def _embed_query(q: str):
+    ql = q.lower()
+    return [1.0, 0.0] if "turbine" in ql else [0.0, 1.0] if "ledger" in ql else [0.5, 0.5]
+
+
+def _fake_search(calls):
+    """A scoped_search that records the doc_ids it was scoped to, and returns store-identity Hits."""
+    def search(query, k, method, doc_ids):
+        calls.append(doc_ids)
+        ids = doc_ids if doc_ids is not None else [c["document_id"] for c in CHUNKS]
+        return [Hit(chunk_id=i, filename="f", text=f"chunk {i}", content_hash=f"h-{i}", version="v1")
+                for i in ids][:k]
+    return search
+
+
+def _index():
+    return RegionIndex.build(CHUNKS, EMB)
+
+
+def test_regions_form_deterministically_from_documents():
+    idx = _index()
+    ids = [r.region_id for r in idx.regions]
+    assert ids == ["alpha", "beta"]                       # sorted, one region per source document
+    # rebuild → identical regions (no seed, no model, stable order)
+    assert [r.region_id for r in RegionIndex.build(CHUNKS, EMB).regions] == ids
+    assert idx.regions[0].doc_ids == ("a0", "a1", "a2")   # references to original evidence, not copies
+
+
+def test_routing_narrows_to_the_relevant_region():
+    calls = []
+    r = SparseRegionRetriever(_index(), _fake_search(calls), _embed_query, top_regions=1)
+    hits = r.search("turbine gearbox oil", k=3)
+    assert calls[-1] == ["a0", "a1", "a2"]                # scoped to the turbine region only
+    assert "alpha" in r.last_reason and "beta" not in r.last_reason
+    assert [h.chunk_id for h in hits] == ["a0", "a1", "a2"]
+
+
+def test_confidence_floor_falls_back_to_global():
+    calls = []
+    # An off-topic query embeds to [0.5,0.5] with no term overlap → no region clears a high floor.
+    r = SparseRegionRetriever(_index(), _fake_search(calls), _embed_query, top_regions=1, floor=0.9)
+    r.search("xyzzy plugh frobnicate", k=6)
+    assert calls[-1] is None                              # global fallback: no doc scope
+    assert "global fallback" in r.last_reason
+
+
+def test_identity_is_transparent():
+    r = SparseRegionRetriever(_index(), _fake_search([]), _embed_query, top_regions=1)
+    hits = r.search("ledger trial balance", k=3)
+    # F4 returns the store's Hits unchanged — provenance (content_hash/version) survives the region layer.
+    assert all(h.content_hash == f"h-{h.chunk_id}" and h.version == "v1" for h in hits)
+    assert [h.chunk_id for h in hits] == ["b0", "b1", "b2"]
+
+
+def test_tenant_scope_filters_regions_before_ranking():
+    idx = _index()
+    # Tag the two regions with tenants; a caller scoped to "t-beta" must never route into alpha.
+    idx.regions[0] = idx.regions[0].__class__(**{**idx.regions[0].__dict__, "tenant": "t-alpha"})
+    idx.regions[1] = idx.regions[1].__class__(**{**idx.regions[1].__dict__, "tenant": "t-beta"})
+    calls = []
+    r = SparseRegionRetriever(idx, _fake_search(calls), _embed_query, top_regions=2, tenant="t-beta")
+    r.search("turbine", k=6)                              # topically alpha, but tenant-scoped to beta
+    assert calls[-1] == ["b0", "b1", "b2"]                # only beta's docs are reachable


### PR DESCRIPTION
## Move F1–F4 from the enterprise overlay into contextos (AGPL)

These optimizations shipped enterprise-only while their benefit was unproven. The long-horizon benchmark — real **Nemotron-3.5-Lightning** answerer, two independent Wikimedia corpora — validated the layer: **managed context beats full context past the model's window at ~27× fewer tokens, reproduced on the holdout**. With the result in hand, there's no reason to keep the implementation behind the enterprise boundary.

| feature | new AGPL home | what it is |
|---|---|---|
| **F4** Evidence Sparse Retrieval | `context_runtime/adapters/sparse_regions.py` | a `RetrieverPlugin`: region index → deterministic routing with a confidence-floor→scoped fallback → the existing hybrid search |
| **F2** Adaptive Materialization | `context_runtime/optimizer/materialization.py` | depth as a planner decision; folds into the bandit arm key **only when non-default**, so `plan_key` identity is byte-preserved |
| **F3** Pattern Memory | `context_runtime/optimizer/pattern_memory.py` | an **additive** prior that warm-starts the *existing* bandit through its own `learn` path — not a second store |
| **F1** ContextState | `context_runtime/context_state.py` | consumes the neutral `runtime-contracts` `ContextView`/`EvidenceChange`; a new `context-state` extra pins runtime-contracts v0.3.2 |

**Logic is unchanged** from the validated enterprise modules — only the license header and import framing. Tests move with them (**28 tests**; the `context_runtime` importorskip is dropped now that it's core, the `runtime_contracts` importorskip stays for F1). `examples/pattern_memory_coldstart.py` reproduces the **38.3% cold-start regret reduction**.

Full contextos suite: **544 passed / 8 skipped**.

Companion PRs: remove the modules from CR-enterprise, and repoint the long-horizon harness arms to the AGPL homes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)